### PR TITLE
Add watched contract from subgraph yaml on startup

### DIFF
--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -291,7 +291,14 @@ export class Indexer implements IndexerInterface {
     return { eventName, eventInfo };
   }
 
-  async watchContract (address: string, checkpoint: boolean, startingBlock: number): Promise<boolean> {
+  async watchContract (address: string, kind: string, checkpoint: boolean, startingBlock?: number): Promise<boolean> {
+    if (!startingBlock) {
+      const syncStatus = await this.getSyncStatus();
+      assert(syncStatus);
+
+      startingBlock = syncStatus.latestIndexedBlockNumber;
+    }
+
     // Always use the checksum address (https://docs.ethers.io/v5/api/utils/address/#utils-getAddress).
     await this._db.saveContract(ethers.utils.getAddress(address), checkpoint, startingBlock);
 

--- a/packages/erc20-watcher/src/resolvers.ts
+++ b/packages/erc20-watcher/src/resolvers.ts
@@ -36,7 +36,7 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
     Mutation: {
       watchToken: (_: any, { token, checkpoint = false, startingBlock = 1 }: { token: string, checkpoint: boolean, startingBlock: number }): Promise<boolean> => {
         log('watchToken', token, checkpoint, startingBlock);
-        return indexer.watchContract(token, checkpoint, startingBlock);
+        return indexer.watchContract(token, 'ERC20', checkpoint, startingBlock);
       }
     },
 

--- a/packages/graph-node/test/subgraph/example1/subgraph.yaml
+++ b/packages/graph-node/test/subgraph/example1/subgraph.yaml
@@ -8,6 +8,7 @@ dataSources:
     source:
       address: ""
       abi: Example1
+      startBlock: 100
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5

--- a/packages/graph-test-watcher/src/indexer.ts
+++ b/packages/graph-test-watcher/src/indexer.ts
@@ -271,8 +271,10 @@ export class Indexer implements IndexerInterface {
     const checkpoint = await this.getLatestIPLDBlock(contractAddress, 'checkpoint');
 
     // There should be an initial checkpoint at least.
-    // Assumption: There should be no events for the contract at the starting block.
-    assert(checkpoint, 'Initial checkpoint doesn\'t exist');
+    // Return if initial checkpoint doesn't exist.
+    if (!checkpoint) {
+      return;
+    }
 
     // Check if the latest checkpoint is in the same block.
     assert(checkpoint.block.blockHash !== block.blockHash, 'Checkpoint already created for the block hash.');
@@ -299,7 +301,7 @@ export class Indexer implements IndexerInterface {
         const checkpointBlock = await this.getLatestIPLDBlock(contract.address, 'checkpoint');
 
         if (!checkpointBlock) {
-          if (blockNumber === contract.startingBlock) {
+          if (blockNumber >= contract.startingBlock) {
             // Call initial checkpoint hook.
             await createInitialCheckpoint(this, contract.address, blockHash);
           }

--- a/packages/graph-test-watcher/src/job-runner.ts
+++ b/packages/graph-test-watcher/src/job-runner.ts
@@ -146,6 +146,9 @@ export const main = async (): Promise<any> => {
   graphWatcher.setIndexer(indexer);
   await graphWatcher.init();
 
+  // Watching all the contracts in the subgraph.
+  await graphWatcher.addContracts();
+
   const jobQueueConfig = config.jobQueue;
   assert(jobQueueConfig, 'Missing job queue config');
 

--- a/packages/graph-test-watcher/src/resolvers.ts
+++ b/packages/graph-test-watcher/src/resolvers.ts
@@ -12,6 +12,7 @@ import { Indexer } from './indexer';
 import { EventWatcher } from './events';
 
 import { ExampleEntity } from './entity/ExampleEntity';
+import { RelatedEntity } from './entity/RelatedEntity';
 
 const log = debug('vulcanize:resolver');
 
@@ -52,6 +53,12 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
       _test: (_: any, { blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<ValueResult> => {
         log('_test', blockHash, contractAddress);
         return indexer._test(blockHash, contractAddress);
+      },
+
+      relatedEntity: async (_: any, { id, blockHash }: { id: string, blockHash: string }): Promise<RelatedEntity | undefined> => {
+        log('relatedEntity', id, blockHash);
+
+        return indexer.getSubgraphEntity(RelatedEntity, id, blockHash);
       },
 
       exampleEntity: async (_: any, { id, blockHash }: { id: string, blockHash: string }): Promise<ExampleEntity | undefined> => {

--- a/packages/graph-test-watcher/src/schema.gql
+++ b/packages/graph-test-watcher/src/schema.gql
@@ -72,6 +72,7 @@ type Query {
   eventsInRange(fromBlockNumber: Int!, toBlockNumber: Int!): [ResultEvent!]
   getMethod(blockHash: String!, contractAddress: String!): ResultString!
   _test(blockHash: String!, contractAddress: String!): ResultBigInt!
+  relatedEntity(id: String!, blockHash: String!): RelatedEntity!
   exampleEntity(id: String!, blockHash: String!): ExampleEntity!
   getStateByCID(cid: String!): ResultIPLDBlock
   getState(blockHash: String!, contractAddress: String!, kind: String): ResultIPLDBlock
@@ -80,6 +81,13 @@ type Query {
 enum EnumType {
   choice1
   choice2
+}
+
+type RelatedEntity {
+  id: ID!
+  paramBigInt: BigInt!
+  examples: [ExampleEntity!]!
+  bigIntArray: [BigInt!]!
 }
 
 type ExampleEntity {
@@ -91,7 +99,7 @@ type ExampleEntity {
   paramBytes: Bytes!
   paramEnum: EnumType!
   paramBigDecimal: BigDecimal!
-  related: String!
+  related: RelatedEntity!
 }
 
 type Mutation {


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/36

Implemented:
- Adding contract from subgraph yaml to be watched on startup
- relatedEntity GQL API