### PR TITLE
Fix block processing job created twice when processing missing parent block

### DIFF
--- a/packages/graph-node/src/loader.ts
+++ b/packages/graph-node/src/loader.ts
@@ -159,7 +159,6 @@ export const instantiate = async (
           // TODO: Check for function overloading.
           let result = await contract[functionName](...functionParams);
 
-          // TODO: Check for function overloading.
           // Using function signature does not work.
           const { outputs } = contract.interface.getFunction(functionName);
           assert(outputs);

--- a/packages/graph-node/test/subgraph/example1/src/mapping.ts
+++ b/packages/graph-node/test/subgraph/example1/src/mapping.ts
@@ -143,7 +143,6 @@ export function testStructEthCall (): void {
   log.debug('In test struct eth call', []);
 
   // Bind the contract to the address that emitted the event.
-  // TODO: Address.fromString throws error in WASM module instantiation.
   const contractAddress = dataSource.address();
   const contract = Example1.bind(contractAddress);
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -163,7 +163,7 @@ export class JobRunner {
         const message = `Parent block number ${parentBlockNumber} hash ${parentHash} of block number ${blockNumber} hash ${blockHash} not fetched yet, aborting`;
         log(message);
 
-        throw new Error(message);
+        return;
       }
 
       if (parentHash !== syncStatus.latestCanonicalBlockHash && !parent.isComplete) {


### PR DESCRIPTION
When job for a missing parent block is created, two jobs for the child block are created after its completion. One is the retry job and the other is created after parent block job is over. The fix prevents the retry job when parent block is missing, since job for next block is created on completing processing of parent block.