### PR TITLE
Add an executable for compare-entity CLI

### DIFF
--- a/packages/graph-node/README.md
+++ b/packages/graph-node/README.md
@@ -61,7 +61,7 @@
   * Fire a query and get the diff of the results from the two GQL endpoints:
 
       ```bash
-      yarn compare-entity --config-file <config-file-path> --query-dir [query-dir] --query-name <query-name> --block-hash <block-hash> --entity-id <entity-id> --raw-json [true | false]
+      ./bin/compare-entity --config-file <config-file-path> --query-dir [query-dir] --query-name <query-name> --block-hash <block-hash> --entity-id <entity-id> --raw-json [true | false]
       ```
 
       * `config-file`(alias: `cf`): Configuration file path (toml) (required).
@@ -74,7 +74,7 @@
       Example:
 
         ```bash
-        yarn compare-entity --config-file environments/compare-cli-config.toml --query-name author --block-hash 0xceed7ee9d3de97c99db12e42433cae9115bb311c516558539fb7114fa17d545b --entity-id 0xdc7d7a8920c8eecc098da5b7522a5f31509b5bfc
+        ./bin/compare-entity --config-file environments/compare-cli-config.toml --query-name author --block-hash 0xceed7ee9d3de97c99db12e42433cae9115bb311c516558539fb7114fa17d545b --entity-id 0xdc7d7a8920c8eecc098da5b7522a5f31509b5bfc
         ```
 
   * The program will exit with code `1` if the query results are not equal.

--- a/packages/graph-node/bin/compare-entity
+++ b/packages/graph-node/bin/compare-entity
@@ -1,0 +1,9 @@
+#! /usr/bin/env node
+
+const { main } = require('../dist/cli/compare/compare-entity')
+
+main().catch(err => {
+  console.log(err);
+}).finally(() => {
+  process.exit(0);
+});

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -24,6 +24,9 @@
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2"
   },
+  "bin": {
+    "compare-entity": "bin/compare-entity"
+  },
   "scripts": {
     "lint": "eslint .",
     "build": "tsc",
@@ -33,7 +36,7 @@
     "test": "yarn asbuild:debug && DEBUG=vulcanize:* mocha src/**/*.test.ts",
     "build:example": "cd test/subgraph/example1 && yarn && yarn build",
     "watch": "DEBUG=vulcanize:* nodemon --watch src src/watcher.ts",
-    "compare-entity": "DEBUG=vulcanize:* ts-node src/cli/compare/compare-entity.ts"
+    "compare-entity": "node bin/compare-entity"
   },
   "dependencies": {
     "@apollo/client": "^3.3.19",

--- a/packages/graph-node/src/cli/compare/compare-entity.ts
+++ b/packages/graph-node/src/cli/compare/compare-entity.ts
@@ -27,7 +27,7 @@ interface Config {
   queries: QueryConfig;
 }
 
-const main = async (): Promise<void> => {
+export const main = async (): Promise<void> => {
   const argv = await yargs.parserConfiguration({
     'parse-numbers': false
   }).options({
@@ -142,9 +142,3 @@ async function getClients (config: Config, queryDir?: string): Promise<{
     client2
   };
 }
-
-main().catch(err => {
-  console.log(err);
-}).finally(() => {
-  process.exit(0);
-});


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/55

Implemented:
An executable for compare-entity CLI that can be used directly while avoiding yarn / npm noise