### PR TITLE
Generate relations and entity types maps in indexer

### DIFF
--- a/packages/codegen/src/entity.ts
+++ b/packages/codegen/src/entity.ts
@@ -11,6 +11,7 @@ import { Writable } from 'stream';
 
 import { getTsForSol, getPgForTs, getTsForGql } from './utils/type-mappings';
 import { Param } from './utils/types';
+import { getFieldType } from './utils/subgraph';
 
 const TEMPLATE_FILE = './templates/entity-template.handlebars';
 const TABLES_DIR = './data/entities';
@@ -334,7 +335,7 @@ export class Entity {
         columnType: 'Column'
       };
 
-      const { typeName, array, nullable } = this._getFieldType(field.type);
+      const { typeName, array, nullable } = getFieldType(field.type);
       let tsType = getTsForGql(typeName);
 
       if (!tsType) {
@@ -395,20 +396,5 @@ export class Entity {
     });
 
     return entityObject;
-  }
-
-  _getFieldType (typeNode: any): { typeName: string, array: boolean, nullable: boolean } {
-    if (typeNode.kind === 'ListType') {
-      return { typeName: this._getFieldType(typeNode.type).typeName, array: true, nullable: true };
-    }
-
-    if (typeNode.kind === 'NonNullType') {
-      const fieldType = this._getFieldType(typeNode.type);
-
-      return { typeName: fieldType.typeName, array: fieldType.array, nullable: false };
-    }
-
-    // If 'NamedType'.
-    return { typeName: typeNode.name.value, array: false, nullable: true };
   }
 }

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -42,6 +42,10 @@ import { HookStatus } from './entity/HookStatus';
 import { BlockProgress } from './entity/BlockProgress';
 import { IPLDBlock } from './entity/IPLDBlock';
 
+{{#each subgraphEntities as | subgraphEntity |}}
+import { {{subgraphEntity.className}} } from './entity/{{subgraphEntity.className}}';
+{{/each}}
+
 const log = debug('vulcanize:indexer');
 
 {{#each events as | event |}}
@@ -129,7 +133,10 @@ export class Indexer implements IndexerInterface {
     this._contract = new ethers.utils.Interface(this._abi);
 
     this._entityTypesMap = new Map();
+    this._populateEntityTypesMap();
+
     this._relationsMap = new Map();
+    this._populateRelationsMap();
   }
 
   async init (): Promise<void> {
@@ -561,6 +568,48 @@ export class Indexer implements IndexerInterface {
 
   async getAncestorAtDepth (blockHash: string, depth: number): Promise<string> {
     return this._baseIndexer.getAncestorAtDepth(blockHash, depth);
+  }
+
+  getEntityTypesMap (): Map<string, { [key: string]: string }> {
+    return this._entityTypesMap;
+  }
+
+  _populateEntityTypesMap (): void {
+  {{#each subgraphEntities as | subgraphEntity |}}
+    this._entityTypesMap.set('{{subgraphEntity.className}}', {
+      {{#each subgraphEntity.columns as | column |}}
+      {{#unless column.isDerived}}
+      {{~#unless @first}},
+      {{/unless}}
+      {{column.name}}: '{{column.type}}'
+      {{~/unless}}
+      {{/each}}
+
+    });
+  {{/each}}
+  }
+
+  _populateRelationsMap (): void {
+  {{#each subgraphEntities as | subgraphEntity |}}
+    {{#if subgraphEntity.relations}}
+    this._relationsMap.set({{subgraphEntity.className}}, {
+      {{#each subgraphEntity.relations as | relation |}}
+      {{~#unless @first}},
+      {{/unless}}
+      {{relation.name}}: {
+        entity: {{relation.type}},
+        isArray: {{relation.isArray}},
+        isDerived: {{relation.isDerived}}
+        {{~#if relation.isDerived}},
+        field: '{{relation.derivedFromField}}'
+        {{~/if}}
+
+      }
+      {{~/each}}
+
+    });
+    {{/if}}
+  {{/each}}
   }
 
   async _fetchAndSaveEvents ({ cid: blockCid, blockHash }: DeepPartial<BlockProgress>): Promise<BlockProgress> {

--- a/packages/codegen/src/utils/subgraph.ts
+++ b/packages/codegen/src/utils/subgraph.ts
@@ -20,9 +20,6 @@ export function parseSubgraphSchema (subgraphPath: string): any {
   const subgraphTypeDefs = subgraphSchemaDocument.definitions;
 
   subgraphTypeDefs.forEach((def: any) => {
-    // Remove type directives.
-    def.directives = [];
-
     if (def.kind === 'ObjectTypeDefinition') {
       def.fields.forEach((field: any) => {
         // Parse the field type.
@@ -35,6 +32,21 @@ export function parseSubgraphSchema (subgraphPath: string): any {
 
   // Return a modified subgraph-schema DocumentNode.
   return subgraphSchemaDocument;
+}
+
+export function getFieldType (typeNode: any): { typeName: string, array: boolean, nullable: boolean } {
+  if (typeNode.kind === 'ListType') {
+    return { typeName: getFieldType(typeNode.type).typeName, array: true, nullable: true };
+  }
+
+  if (typeNode.kind === 'NonNullType') {
+    const fieldType = getFieldType(typeNode.type);
+
+    return { typeName: fieldType.typeName, array: fieldType.array, nullable: false };
+  }
+
+  // If 'NamedType'.
+  return { typeName: typeNode.name.value, array: false, nullable: true };
 }
 
 function parseType (typeNode: any): any {

--- a/packages/codegen/src/utils/type-mappings.ts
+++ b/packages/codegen/src/utils/type-mappings.ts
@@ -15,6 +15,7 @@ _solToTs.set('uint16', 'number');
 _solToTs.set('uint64', 'bigint');
 _solToTs.set('uint128', 'bigint');
 _solToTs.set('uint256', 'bigint');
+_solToTs.set('uint', 'bigint');
 _solToTs.set('address', 'string');
 _solToTs.set('bool', 'boolean');
 _solToTs.set('bytes', 'string');

--- a/packages/codegen/src/visitor.ts
+++ b/packages/codegen/src/visitor.ts
@@ -76,6 +76,7 @@ export class Visitor {
   stateVariableDeclarationVisitor (node: any): void {
     // TODO Handle multiples variables in a single line.
     // TODO Handle array types.
+    // TODO Handle user defined type .
     const variable = node.variables[0];
     const name: string = variable.name;
     const stateVariableType: string = variable.typeName.type;
@@ -83,13 +84,6 @@ export class Visitor {
     const params: Param[] = [];
 
     let typeName = variable.typeName;
-
-    // TODO Handle user defined type.
-    if (typeName.type === 'UserDefinedTypeName') {
-      // Skip in case of UserDefinedTypeName.
-      return;
-    }
-
     let numParams = 0;
 
     // If the variable type is mapping, extract key as a param:
@@ -98,6 +92,11 @@ export class Visitor {
       params.push({ name: `key${numParams.toString()}`, type: typeName.keyType.name });
       typeName = typeName.valueType;
       numParams++;
+    }
+
+    if (['UserDefinedTypeName', 'ArrayTypeName'].includes(typeName.type)) {
+      // Skip in case of UserDefinedTypeName | ArrayTypeName.
+      return;
     }
 
     const returnType = typeName.name;
@@ -138,6 +137,7 @@ export class Visitor {
     this._entity.addSubgraphEntities(subgraphSchemaDocument);
     this._resolvers.addSubgraphResolvers(subgraphSchemaDocument);
     this._reset.addSubgraphEntities(subgraphSchemaDocument);
+    this._indexer.addSubgraphEntities(subgraphSchemaDocument);
   }
 
   /**


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/39

- Use type definitions from the subgraph schema to generate relations and entity types maps in the indexer.