### PR TITLE
Implement Block_height input and definition for custom scalar BigDecimal in codegen

### DIFF
--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -156,6 +156,16 @@ export class Schema {
     const subgraphTypeDefsString = print(modifiedSchemaDocument);
     this._composer.addTypeDefs(subgraphTypeDefsString);
 
+    // Create the Block_height input needed in subgraph queries.
+    const typeComposer = this._composer.createInputTC({
+      name: 'Block_height',
+      fields: {
+        hash: 'Bytes',
+        number: 'Int'
+      }
+    });
+    this._composer.addSchemaMustHaveType(typeComposer);
+
     // Add subgraph-schema entity queries to the schema composer.
     this._addSubgraphSchemaQueries(subgraphTypeDefs);
   }
@@ -178,7 +188,7 @@ export class Schema {
         type: this._composer.getAnyTC(subgraphType).NonNull,
         args: {
           id: 'String!',
-          blockHash: 'String!'
+          block: 'Block_height'
         }
       };
 

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -5,6 +5,8 @@
 import assert from 'assert';
 import BigInt from 'apollo-type-bigint';
 import debug from 'debug';
+import Decimal from 'decimal.js';
+import { GraphQLScalarType } from 'graphql';
 
 import { ValueResult, BlockHeight, StateKind } from '@vulcanize/util';
 
@@ -22,6 +24,19 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
   return {
     BigInt: new BigInt('bigInt'),
+
+    BigDecimal: new GraphQLScalarType({
+      name: 'BigDecimal',
+      description: 'BigDecimal custom scalar type',
+      parseValue (value) {
+        // value from the client
+        return new Decimal(value);
+      },
+      serialize (value: Decimal) {
+        // value sent to the client
+        return value.toFixed();
+      }
+    }),
 
     Event: {
       __resolveType: (obj: any) => {


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/39

- Add Block_height input type for subgraph queries.
- Add definition for BigDecimal scalar in resolver.