### PR TITLE
Fixes in codegen after comparing with existing eden watcher

### DIFF
--- a/packages/codegen/src/client.ts
+++ b/packages/codegen/src/client.ts
@@ -79,6 +79,7 @@ export class Client {
   }
 
   _exportGql (schemaContent: string, gqlDir: string): void {
-    gqlGenerate(schemaContent, gqlDir);
+    // TODO: Implement nested queries for subgraph entities.
+    gqlGenerate(schemaContent, gqlDir, 2);
   }
 }

--- a/packages/codegen/src/entity.ts
+++ b/packages/codegen/src/entity.ts
@@ -427,22 +427,6 @@ export class Entity {
       const { typeName, array, nullable } = getFieldType(field.type);
       let tsType = getTsForGql(typeName);
 
-      if (!tsType) {
-        tsType = 'string';
-      }
-
-      columnObject.tsType = tsType;
-
-      // Handle basic array types.
-      if (array) {
-        columnObject.columnOptions.push({
-          option: 'array',
-          value: 'true'
-        });
-
-        columnObject.tsType = `${tsType}[]`;
-      }
-
       if (subgraphTypeDefs.some((typeDef: any) => typeDef.kind === 'EnumTypeDefinition' && typeDef.name.value === typeName)) {
         // Create enum type column.
 
@@ -469,9 +453,27 @@ export class Entity {
             value: typeName
           }
         );
+
+        columnObject.tsType = typeName;
       } else {
+        if (!tsType) {
+          tsType = 'string';
+        }
+
+        columnObject.tsType = tsType;
+
         // Enum type does not require pgType.
         columnObject.pgType = getPgForTs(tsType);
+      }
+
+      // Handle basic array types.
+      if (array) {
+        columnObject.columnOptions.push({
+          option: 'array',
+          value: 'true'
+        });
+
+        columnObject.tsType = `${tsType}[]`;
       }
 
       if (nullable) {

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -85,6 +85,11 @@ export class Schema {
         acc[curr.name] = `${getGqlForTs(tsCurrType)}!`;
         return acc;
       }, typeObject.fields);
+    } else {
+      // Types must define one or more fields.
+      typeObject.fields = {
+        dummy: 'String'
+      };
     }
 
     // Create a type composer to add the required type in the schema composer.

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -14,6 +14,7 @@
 
   {{#if subgraphPath}}
   subgraphPath = "{{subgraphPath}}"
+  wasmRestartBlocksInterval = 20
   {{/if}}
 
 [database]

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -14,7 +14,6 @@ import { SyncStatus } from './entity/SyncStatus';
 import { HookStatus } from './entity/HookStatus';
 import { BlockProgress } from './entity/BlockProgress';
 import { IPLDBlock } from './entity/IPLDBlock';
-
 {{#each queries as | query |}}
 import { {{query.entityName}} } from './entity/{{query.entityName}}';
 {{/each}}
@@ -39,7 +38,9 @@ export class Database implements IPLDDatabaseInterface {
 
   async init (): Promise<void> {
     this._conn = await this._baseDatabase.init();
+    {{#if queries}}
     this._setPropColMaps();
+    {{/if}}
   }
 
   async close (): Promise<void> {
@@ -249,10 +250,12 @@ export class Database implements IPLDDatabaseInterface {
       return acc.set(curr.propertyName, curr.databaseName);
     }, new Map<string, string>());
   }
+  {{#if queries}}
 
   _setPropColMaps (): void {
     {{#each queries as | query |}}
     this._propColMaps.{{query.entityName}} = this._getPropertyColumnMapForEntity('{{query.entityName}}');
     {{/each}}
   }
+  {{/if}}
 }

--- a/packages/codegen/src/templates/fill-template.handlebars
+++ b/packages/codegen/src/templates/fill-template.handlebars
@@ -63,10 +63,6 @@ export const main = async (): Promise<any> => {
 
   const graphWatcher = new GraphWatcher(graphDb, postgraphileClient, ethProvider, config.server);
 
-  // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
-  // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
-  const pubsub = new PubSub();
-
   const jobQueueConfig = config.jobQueue;
   assert(jobQueueConfig, 'Missing job queue config');
 
@@ -81,6 +77,10 @@ export const main = async (): Promise<any> => {
 
   graphWatcher.setIndexer(indexer);
   await graphWatcher.init();
+
+  // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
+  // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
+  const pubsub = new PubSub();
 
   const eventWatcher = new EventWatcher(config.upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
 

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -35,6 +35,7 @@
     "@vulcanize/ipld-eth-client": "^0.1.0",
     "@vulcanize/solidity-mapper": "^0.1.0",
     "@vulcanize/util": "^0.1.0",
+    "@vulcanize/graph-node": "^0.1.0",
     "apollo-server-express": "^2.25.0",
     "apollo-type-bigint": "^0.1.3",
     "debug": "^4.3.1",
@@ -48,7 +49,8 @@
     "multiformats": "^9.4.8",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.32",
-    "yargs": "^17.0.1"
+    "yargs": "^17.0.1",
+    "decimal.js": "^10.3.1"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.3.0",

--- a/packages/codegen/src/templates/watch-contract-template.handlebars
+++ b/packages/codegen/src/templates/watch-contract-template.handlebars
@@ -83,7 +83,6 @@ const main = async (): Promise<void> => {
 
   await db.close();
   await jobQueue.stop();
-  process.exit();
 };
 
 main().catch(err => {


### PR DESCRIPTION
Part of #39 

- Generate queries with nesting of relations up to 1 level.
- Fix enum type fields in subgraph entities.
- Implement dummy field for event type without params in gql schema.
- Add wasmRestartBlocksInterval to watcher config