### PR TITLE
Generate schema from ABI when using subgraph path

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -23,6 +23,7 @@
   ```yaml
   # Example config.yaml
   # Contracts to watch (required).
+  # Can pass empty array ([]) when using subgraphPath.
   contracts:
       # Contract name.
     - name: Example
@@ -34,8 +35,8 @@
   # Output folder path (logs output using `stdout` if not provided).
   outputFolder: ../test-watcher
 
-  # Code generation mode [eth_call | storage | all | none] (default: all).
-  mode: all
+  # Code generation mode [eth_call | storage | all | none] (default: none).
+  mode: none
 
   # Kind of watcher [lazy | active] (default: active).
   kind: active
@@ -47,6 +48,7 @@
   flatten: true
 
   # Path to the subgraph build (optional).
+  # Can set empty contracts array when using subgraphPath.
   subgraphPath: ../graph-node/test/subgraph/example1/build
 
   # NOTE: When passed an *URL* as contract path, it is assumed that it points to an already flattened contract file.
@@ -149,7 +151,7 @@
     ```bash
     yarn checkpoint --address <contract-address> --block-hash [block-hash]
     ```
-  
+
   * To reset the watcher to a previous block number:
 
     * Reset state:
@@ -175,7 +177,7 @@
     ```bash
     yarn import-state --import-file <import-file-path>
     ```
-  
+
   * To inspect a CID:
 
     ```bash

--- a/packages/codegen/src/artifacts.ts
+++ b/packages/codegen/src/artifacts.ts
@@ -3,16 +3,14 @@
 //
 
 import solc from 'solc';
-import { Writable } from 'stream';
 
 /**
- * Compiles the given contract using solc and writes the resultant artifacts to a file.
- * @param outStream A writable output stream to write the artifacts file to.
+ * Compiles the given contract using solc and returns resultant artifacts.
  * @param contractContent Contents of the contract file to be compiled.
  * @param contractFileName Input contract file name.
  * @param contractName Name of the main contract in the contract file.
  */
-export function exportArtifacts (outStream: Writable, contractContent: string, contractFileName: string, contractName: string): void {
+export function generateArtifacts (contractContent: string, contractFileName: string, contractName: string): { abi: any[], storageLayout: any } {
   const input: any = {
     language: 'Solidity',
     sources: {},
@@ -30,6 +28,5 @@ export function exportArtifacts (outStream: Writable, contractContent: string, c
   };
 
   // Get artifacts for the required contract.
-  const output = JSON.parse(solc.compile(JSON.stringify(input))).contracts[contractFileName][contractName];
-  outStream.write(JSON.stringify(output, null, 2));
+  return JSON.parse(solc.compile(JSON.stringify(input))).contracts[contractFileName][contractName];
 }

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -31,7 +31,7 @@ import {
 import { GraphWatcher } from '@vulcanize/graph-node';
 
 {{#each contracts as | contract |}}
-import {{contract.name}}Artifacts from './artifacts/{{contract.name}}.json';
+import {{contract.contractName}}Artifacts from './artifacts/{{contract.contractName}}.json';
 {{/each}}
 import { Database } from './database';
 import { createInitialState, handleEvent, createStateDiff, createStateCheckpoint } from './hooks';
@@ -49,7 +49,7 @@ import { {{subgraphEntity.className}} } from './entity/{{subgraphEntity.classNam
 const log = debug('vulcanize:indexer');
 
 {{#each contracts as | contract |}}
-const KIND_{{capitalize contract.name}} = '{{contract.kind}}';
+const KIND_{{capitalize contract.contractName}} = '{{contract.contractKind}}';
 {{/each}}
 
 {{#each uniqueEvents as | event |}}
@@ -131,15 +131,22 @@ export class Indexer implements IndexerInterface {
     this._contractMap = new Map();
 
     {{#each contracts as | contract |}}
-    const { abi: {{contract.name}}ABI, storageLayout: {{contract.name}}StorageLayout } = {{contract.name}}Artifacts;
-    assert({{contract.name}}ABI);
-    assert({{contract.name}}StorageLayout);
+    const {
+      abi: {{contract.contractName}}ABI,
+      {{#if contract.contractStorageLayout}}
+      storageLayout: {{contract.contractName}}StorageLayout
+      {{/if}}
+    } = {{contract.contractName}}Artifacts;
 
     {{/each}}
     {{#each contracts as | contract |}}
-    this._abiMap.set(KIND_{{capitalize contract.name}}, {{contract.name}}ABI);
-    this._storageLayoutMap.set(KIND_{{capitalize contract.name}}, {{contract.name}}StorageLayout);
-    this._contractMap.set(KIND_{{capitalize contract.name}}, new ethers.utils.Interface({{contract.name}}ABI));
+    assert({{contract.contractName}}ABI);
+    this._abiMap.set(KIND_{{capitalize contract.contractName}}, {{contract.contractName}}ABI);
+    {{#if contract.contractStorageLayout}}
+    assert({{contract.contractName}}StorageLayout);
+    this._storageLayoutMap.set(KIND_{{capitalize contract.contractName}}, {{contract.contractName}}StorageLayout);
+    {{/if}}
+    this._contractMap.set(KIND_{{capitalize contract.contractName}}, new ethers.utils.Interface({{contract.contractName}}ABI));
 
     {{/each}}
     this._entityTypesMap = new Map();
@@ -434,8 +441,8 @@ export class Indexer implements IndexerInterface {
 
     switch (kind) {
       {{#each contracts as | contract |}}
-      case KIND_{{capitalize contract.name}}: {
-        ({ eventName, eventInfo } = this.parse{{contract.name}}Event(logDescription));
+      case KIND_{{capitalize contract.contractName}}: {
+        ({ eventName, eventInfo } = this.parse{{contract.contractName}}Event(logDescription));
 
         break;
       }
@@ -450,13 +457,13 @@ export class Indexer implements IndexerInterface {
   }
 
   {{#each contracts as | contract |}}
-  parse{{contract.name}}Event (logDescription: ethers.utils.LogDescription): { eventName: string, eventInfo: any } {
+  parse{{contract.contractName}}Event (logDescription: ethers.utils.LogDescription): { eventName: string, eventInfo: any } {
     let eventName = UNKNOWN_EVENT_NAME;
     let eventInfo = {};
 
     switch (logDescription.name) {
       {{#each ../events as | event |}}
-      {{#if (compare contract.kind event.kind)}}
+      {{#if (compare contract.contractKind event.kind)}}
       case {{capitalize event.name}}_EVENT: {
         eventName = logDescription.name;
         {{#if event.params}}

--- a/packages/codegen/src/utils/subgraph.ts
+++ b/packages/codegen/src/utils/subgraph.ts
@@ -45,17 +45,11 @@ export function getFieldType (typeNode: any): { typeName: string, array: boolean
   return { typeName: typeNode.name.value, array: false, nullable: true };
 }
 
-export function getContractKindList (subgraphPath: string): string[] {
+export function getSubgraphConfig (subgraphPath: string): any {
   const subgraphConfigPath = path.join(path.resolve(subgraphPath), '/subgraph.yaml');
 
   assert(fs.existsSync(subgraphConfigPath), `Subgraph config file not found at ${subgraphConfigPath}`);
-  const subgraph = yaml.load(fs.readFileSync(subgraphConfigPath, 'utf8')) as any;
-
-  const contractKinds: string[] = subgraph.dataSources.map((dataSource: any) => {
-    return dataSource.name;
-  });
-
-  return contractKinds;
+  return yaml.load(fs.readFileSync(subgraphConfigPath, 'utf8')) as any;
 }
 
 function parseType (typeNode: any): any {


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/39

ABIs specified in subgraph build is used by codegen to generate watcher in mode `none` when `subgraphPath` is specified.
In codegen config `contracts` can be set to empty array when using `subgraphPath`. 