### PR TITLE
Get missing fields in transaction data for subgraph event handlers

### DIFF
--- a/packages/graph-node/src/loader.ts
+++ b/packages/graph-node/src/loader.ts
@@ -42,9 +42,7 @@ export interface GraphData {
 }
 
 export interface Context {
-  event: {
-    block?: Block
-  }
+  block?: Block
 }
 
 const log = debug('vulcanize:graph-node');
@@ -71,8 +69,8 @@ export const instantiate = async (
         const entityName = __getString(entity);
         const entityId = __getString(id);
 
-        assert(context.event.block);
-        const entityData = await database.getEntity(entityName, entityId, context.event.block.blockHash);
+        assert(context.block);
+        const entityData = await database.getEntity(entityName, entityId, context.block.blockHash);
 
         if (!entityData) {
           return null;
@@ -91,8 +89,8 @@ export const instantiate = async (
 
         const entityInstance = await Entity.wrap(data);
 
-        assert(context.event.block);
-        let dbData = await database.fromGraphEntity(instanceExports, context.event.block, entityName, entityInstance);
+        assert(context.block);
+        let dbData = await database.fromGraphEntity(instanceExports, context.block, entityName, entityInstance);
         await database.saveEntity(entityName, dbData);
 
         // Resolve any field name conflicts in the dbData for auto-diff.
@@ -108,7 +106,7 @@ export const instantiate = async (
         // Create an auto-diff.
         assert(indexer.createDiffStaged);
         assert(dataSource?.address);
-        await indexer.createDiffStaged(dataSource.address, context.event.block.blockHash, diffData);
+        await indexer.createDiffStaged(dataSource.address, context.block.blockHash, diffData);
       },
 
       'log.log': (level: number, msg: number) => {
@@ -161,10 +159,10 @@ export const instantiate = async (
 
           functionParams = await Promise.all(functionParamsPromise);
 
-          assert(context.event.block);
+          assert(context.block);
 
           // TODO: Check for function overloading.
-          let result = await contract[functionName](...functionParams, { blockTag: context.event.block.blockHash });
+          let result = await contract[functionName](...functionParams, { blockTag: context.block.blockHash });
 
           // Using function signature does not work.
           const { outputs } = contract.interface.getFunction(functionName);

--- a/packages/graph-node/src/utils.ts
+++ b/packages/graph-node/src/utils.ts
@@ -5,7 +5,7 @@ import debug from 'debug';
 import yaml from 'js-yaml';
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 
-import { getExtraTxData, GraphDecimal } from '@vulcanize/util';
+import { GraphDecimal } from '@vulcanize/util';
 
 import { TypeId, EthereumValueKind, ValueKind } from './types';
 
@@ -26,15 +26,19 @@ export const DECIMAL128_PMIN = '1e-6143';
 // Maximum -ve decimal value.
 export const DECIMAL128_NMAX = '-1e-6143';
 
-interface Transaction {
+export interface Transaction {
   hash: string;
   index: number;
   from: string;
   to: string;
-  rlpData: string;
+  value: string;
+  gasLimit: string;
+  gasPrice: string;
+  input: string;
 }
 
 export interface Block {
+  headerId: number;
   blockHash: string;
   blockNumber: string;
   timestamp: string;
@@ -232,19 +236,18 @@ export const createEvent = async (instanceExports: any, contractAddress: string,
   const txToStringPtr = await __newString(tx.to);
   const txTo = tx.to && await Address.fromString(txToStringPtr);
 
-  const { value, gasLimit, gasPrice, input } = getExtraTxData(tx.rlpData);
-
-  const valueStringPtr = await __newString(value);
+  const valueStringPtr = await __newString(tx.value);
   const txValuePtr = await BigInt.fromString(valueStringPtr);
 
-  const gasLimitStringPtr = await __newString(gasLimit);
+  const gasLimitStringPtr = await __newString(tx.gasLimit);
   const txGasLimitPtr = await BigInt.fromString(gasLimitStringPtr);
 
-  const gasPriceStringPtr = await __newString(gasPrice);
+  const gasPriceStringPtr = await __newString(tx.gasPrice);
   const txGasPricePtr = await BigInt.fromString(gasPriceStringPtr);
 
-  const inputStringPtr = await __newString(input);
-  const txInputPtr = await Bytes.fromString(inputStringPtr);
+  const inputStringPtr = await __newString(tx.input);
+  const txInputByteArray = await ByteArray.fromHexString(inputStringPtr);
+  const txInputPtr = await Bytes.fromByteArray(txInputByteArray);
 
   const transaction = await ethereum.Transaction.__new(
     txHash,

--- a/packages/graph-node/test/subgraph/example1/src/mapping.ts
+++ b/packages/graph-node/test/subgraph/example1/src/mapping.ts
@@ -8,21 +8,11 @@ import { Author, Blog, Category } from '../generated/schema';
 
 export function handleTest (event: Test): void {
   log.debug('event.address: {}', [event.address.toHexString()]);
-  // log.debug('event.params.param1: {}', [event.params.param1]);
-  // log.debug('event.params.param2: {}', [event.params.param2.toString()]);
-  // log.debug('event.params.param3: {}', [event.params.param3.toString()]);
-  // log.debug('event.block.hash: {}', [event.block.hash.toHexString()]);
-  // log.debug('event.block.stateRoot: {}', [event.block.stateRoot.toHexString()]);
-
-  // event
-  log.debug('event.transactionLogIndex: {}', [event.transactionLogIndex.toString()]);
-  log.debug('event.logType: {}', [event.logType]);
-
-  // transaction
-  log.debug('event.transaction.value: {}', [event.transaction.value.toString()]);
-  log.debug('event.transaction.gasLimit: {}', [event.transaction.gasLimit.toString()]);
-  log.debug('event.transaction.gasPrice: {}', [event.transaction.gasPrice.toString()]);
-  log.debug('event.transaction.input: {}', [event.transaction.input.toString()]);
+  log.debug('event.params.param1: {}', [event.params.param1]);
+  log.debug('event.params.param2: {}', [event.params.param2.toString()]);
+  log.debug('event.params.param3: {}', [event.params.param3.toString()]);
+  log.debug('event.block.hash: {}', [event.block.hash.toHexString()]);
+  log.debug('event.block.stateRoot: {}', [event.block.stateRoot.toHexString()]);
 
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type

--- a/packages/graph-test-watcher/src/indexer.ts
+++ b/packages/graph-test-watcher/src/indexer.ts
@@ -59,7 +59,6 @@ export type ResultEvent = {
     from: string;
     to: string;
     index: number;
-    rlpData: string;
   };
 
   contract: string;
@@ -157,8 +156,7 @@ export class Indexer implements IndexerInterface {
         hash: event.txHash,
         from: tx.src,
         to: tx.dst,
-        index: tx.index,
-        rlpData: tx.blockByMhKey.data
+        index: tx.index
       },
 
       contract: event.contract,

--- a/packages/ipld-eth-client/src/eth-client.ts
+++ b/packages/ipld-eth-client/src/eth-client.ts
@@ -92,6 +92,16 @@ export class EthClient {
     );
   }
 
+  async getFullTransaction ({ headerId, txHash }: { headerId: number, txHash: string }): Promise<any> {
+    return this._graphqlClient.query(
+      ethQueries.getFullTransaction,
+      {
+        headerId,
+        txHash
+      }
+    );
+  }
+
   async getBlockByHash (blockHash?: string): Promise<any> {
     const { block } = await this._graphqlClient.query(ethQueries.getBlockByHash, { blockHash });
     block.number = parseInt(block.number, 16);

--- a/packages/ipld-eth-client/src/eth-queries.ts
+++ b/packages/ipld-eth-client/src/eth-queries.ts
@@ -57,9 +57,6 @@ query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
           index
           src
           dst
-          blockByMhKey {
-            data
-          }
         }
       }
     }
@@ -89,6 +86,7 @@ export const getFullBlocks = gql`
 query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
   allEthHeaderCids(condition: { blockNumber: $blockNumber, blockHash: $blockHash }) {
     nodes {
+      id
       cid
       blockNumber
       blockHash
@@ -104,6 +102,21 @@ query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
         key
         data
       }
+    }
+  }
+}
+`;
+
+export const getFullTransaction = gql`
+query ethTransactionCidByHeaderIdAndTxHash($headerId: Int!, $txHash: String!) {
+  ethTransactionCidByHeaderIdAndTxHash(headerId: $headerId, txHash: $txHash) {
+    cid
+    txHash
+    index
+    src
+    dst
+    blockByMhKey {
+      data
     }
   }
 }
@@ -161,6 +174,7 @@ export default {
   getBlockWithTransactions,
   getBlocks,
   getFullBlocks,
+  getFullTransaction,
   getBlockByHash,
   subscribeBlocks,
   subscribeTransactions

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -225,13 +225,13 @@ export class JobRunner {
       blockProgress = await this._indexer.fetchBlockEvents({ cid, blockHash, blockNumber, parentHash, blockTimestamp: timestamp });
     }
 
+    if (this._indexer.processBlock) {
+      await this._indexer.processBlock(blockHash, blockNumber);
+    }
+
     // Check if block has unprocessed events.
     if (blockProgress.numProcessedEvents < blockProgress.numEvents) {
       await this._jobQueue.pushJob(QUEUE_EVENT_PROCESSING, { kind: JOB_KIND_EVENTS, blockHash: blockProgress.blockHash, publish: true });
-    }
-
-    if (this._indexer.processBlock) {
-      await this._indexer.processBlock(blockHash, blockNumber);
     }
 
     const indexBlockDuration = new Date().getTime() - indexBlockStartTime.getTime();

--- a/packages/util/src/misc.ts
+++ b/packages/util/src/misc.ts
@@ -194,6 +194,7 @@ export const getFullBlock = async (ethClient: EthClient, ethProvider: providers.
   const { size } = await provider.send('eth_getBlockByHash', [blockHash, false]);
 
   return {
+    headerId: fullBlock.id,
     cid: fullBlock.cid,
     blockNumber: fullBlock.blockNumber,
     blockHash: fullBlock.blockHash,
@@ -212,15 +213,25 @@ export const getFullBlock = async (ethClient: EthClient, ethProvider: providers.
   };
 };
 
-export const getExtraTxData = (rlpData: string): any => {
-  // Deecode the transaction data.
-  const header = EthDecoder.decodeTransaction(EthDecoder.decodeData(rlpData));
-  assert(header);
+export const getFullTransaction = async (ethClient: EthClient, headerId: number, txHash: string): Promise<any> => {
+  const {
+    ethTransactionCidByHeaderIdAndTxHash: fullTx
+  } = await ethClient.getFullTransaction({ headerId, txHash });
+
+  assert(fullTx.blockByMhKey);
+
+  // Decode the transaction data.
+  const extraData = EthDecoder.decodeTransaction(EthDecoder.decodeData(fullTx.blockByMhKey.data));
+  assert(extraData);
 
   return {
-    value: header.Amount.toString(),
-    gasLimit: header.GasLimit.toString(),
-    gasPrice: header.GasPrice.toString(),
-    input: header.Data
+    hash: txHash,
+    from: fullTx.src,
+    to: fullTx.dst,
+    index: fullTx.index,
+    value: extraData.Amount.toString(),
+    gasLimit: extraData.GasLimit.toString(),
+    gasPrice: extraData.GasPrice.toString(),
+    input: extraData.Data
   };
 };


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/14

- Get missing transaction fields from rlp encoded data.
- Cache transaction data for handling multiple events in the same transaction.
- Complete block processing before event processing in job-runner.