### PR TITLE
Fix running erc20-watcher as active kind watcher

### DIFF
--- a/packages/erc20-watcher/README.md
+++ b/packages/erc20-watcher/README.md
@@ -33,8 +33,33 @@ createdb erc20-watcher
 ```
 
 Update `environments/local.toml` with database connection settings for both the databases.
+```toml
+[database]
+  type = "postgres"
+  host = "localhost"
+  port = 5432
+  database = "erc20-watcher"
+  username = "postgres"
+  password = "postgres"
 
-Update the `upstream` config in `environments/local.toml` and provide the `ipld-eth-server` GQL API and the `indexer-db` postgraphile endpoints.
+[jobQueue]
+  dbConnectionString = "postgres://postgres:postgres@localhost/erc20-watcher-job-queue"
+```
+
+Update the `upstream` config in `environments/local.toml`. Provide the `ipld-eth-server` GQL and RPC API and the `indexer-db` postgraphile endpoints.
+```toml
+[upstream]
+  [upstream.ethServer]
+    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
+    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8081"
+```
+
+Ensure that watcher is of active kind. Update the kind in `server` config to active.
+```toml
+[server]
+  kind = "active"
+```
 
 ## Run
 
@@ -69,6 +94,11 @@ $ yarn job-runner -f environments/local.toml
 ```
 
 GQL console: http://localhost:3001/graphql
+
+Deploy an ERC20 token:
+```bash
+$ yarn token:deploy
+```
 
 Start watching a token:
 

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -76,6 +76,10 @@ export class Indexer implements IndexerInterface {
     this._contract = new ethers.utils.Interface(this._abi);
   }
 
+  async init (): Promise<void> {
+    await this._baseIndexer.fetchContracts();
+  }
+
   getResultEvent (event: Event): EventResult {
     const eventFields = JSON.parse(event.eventInfo);
 
@@ -301,6 +305,10 @@ export class Indexer implements IndexerInterface {
 
   async watchContract (address: string, kind: string, checkpoint: boolean, startingBlock: number): Promise<void> {
     return this._baseIndexer.watchContract(address, kind, checkpoint, startingBlock);
+  }
+
+  cacheContract (contract: Contract): void {
+    return this._baseIndexer.cacheContract(contract);
   }
 
   async saveEventEntity (dbEvent: Event): Promise<Event> {

--- a/packages/erc20-watcher/src/job-runner.ts
+++ b/packages/erc20-watcher/src/job-runner.ts
@@ -83,6 +83,7 @@ export const main = async (): Promise<any> => {
   await jobQueue.start();
 
   const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, config.server.mode);
+  await indexer.init();
 
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);
   await jobRunner.start();

--- a/packages/erc20-watcher/src/server.ts
+++ b/packages/erc20-watcher/src/server.ts
@@ -56,6 +56,7 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
 
   const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  await indexer.init();
 
   const eventWatcher = new EventWatcher(config.upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
 

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -209,12 +209,14 @@ export class Indexer {
   }
 
   async getEventsByFilter (blockHash: string, contract?: string, name?: string): Promise<Array<EventInterface>> {
-    if (contract) {
-      const watchedContract = await this.isWatchedContract(contract);
-      if (!watchedContract) {
-        throw new Error('Not a watched contract');
-      }
-    }
+    // TODO: Uncomment after implementing hot reload of watched contracts in server process.
+    // This doesn't affect functionality as we already have a filter condition on the contract in the query.
+    // if (contract) {
+    //   const watchedContract = await this.isWatchedContract(contract);
+    //   if (!watchedContract) {
+    //     throw new Error('Not a watched contract');
+    //   }
+    // }
 
     const where: Where = {
       eventName: [{


### PR DESCRIPTION
Part of https://github.com/vulcanize/graph-watcher-ts/issues/115
- Add missing methods to watch contract in erc20-watcher indexer.
- Comment check for watched contracts in querying events by filter.