### PR TITLE
Fix fill blocks CLI to check that endBlock is greater than chainHeadBlock

### DIFF
--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -45,6 +45,7 @@ export const fillBlocks = async (
       throw new Error(`Missing blocks between startBlock ${startBlock} and chainHeadBlockNumber ${syncStatus.chainHeadBlockNumber}`);
     }
 
+    assert(endBlock > syncStatus.chainHeadBlockNumber, 'endBlock should be greater than chainHeadBlockNumber');
     startBlock = syncStatus.chainHeadBlockNumber + 1;
   }
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/154