### PR TITLE
Update meta data verification to allow branched checkpoints

### DIFF
--- a/packages/graph-node/src/cli/compare/compare-blocks.ts
+++ b/packages/graph-node/src/cli/compare/compare-blocks.ts
@@ -64,7 +64,7 @@ export const main = async (): Promise<void> => {
   let diffFound = false;
   let blockDelay = wait(0);
   let subgraphContracts: string[] = [];
-  const contractLatestStateCIDMap: Map<string, string> = new Map();
+  const contractLatestStateCIDMap: Map<string, { diff: string, checkpoint: string }> = new Map();
   let db: Database | undefined, subgraphGQLClient: GraphQLClient | undefined;
 
   if (config.watcher) {
@@ -82,7 +82,7 @@ export const main = async (): Promise<void> => {
     }
 
     subgraphContracts.forEach(subgraphContract => {
-      contractLatestStateCIDMap.set(subgraphContract, '');
+      contractLatestStateCIDMap.set(subgraphContract, { diff: '', checkpoint: '' });
     });
   }
 


### PR DESCRIPTION
Part of #70

- In case a state `diff` at a block gets created before the `checkpoint` creation at the previous block completes, allow the `diff` to point to `diff` (instead of `checkpoint`) at previous block as a parent
- Same scenario occurs when the `checkpoint` is taken externally