### PR TITLE
Add DB queries to fetch entities without checking pruned block 

### DIFF
--- a/packages/graph-node/src/index.ts
+++ b/packages/graph-node/src/index.ts
@@ -2,5 +2,6 @@ export * from './watcher';
 export * from './database';
 export {
   prepareEntityState,
-  updateEntitiesFromState
+  updateEntitiesFromState,
+  resolveEntityFieldConflicts
 } from './utils';

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -26,7 +26,7 @@ import { BlockProgressInterface, ContractInterface, EventInterface, StateInterfa
 import { MAX_REORG_DEPTH, UNKNOWN_EVENT_NAME } from './constants';
 import { blockProgressCount, eventCount } from './metrics';
 
-const OPERATOR_MAP = {
+export const OPERATOR_MAP = {
   equals: '=',
   gt: '>',
   lt: '<',


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191