### PR TITLE
Avoid creating a separate base db instance for graph database

### DIFF
--- a/packages/codegen/src/templates/checkpoint-create-template.handlebars
+++ b/packages/codegen/src/templates/checkpoint-create-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import debug from 'debug';
 import assert from 'assert';
 
@@ -44,7 +41,7 @@ export const handler = async (argv: any): Promise<void> => {
 
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/checkpoint-create-template.handlebars
+++ b/packages/codegen/src/templates/checkpoint-create-template.handlebars
@@ -41,7 +41,7 @@ export const handler = async (argv: any): Promise<void> => {
 
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/checkpoint-verify-template.handlebars
+++ b/packages/codegen/src/templates/checkpoint-verify-template.handlebars
@@ -34,7 +34,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/checkpoint-verify-template.handlebars
+++ b/packages/codegen/src/templates/checkpoint-verify-template.handlebars
@@ -34,7 +34,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -36,6 +36,10 @@ export class Database implements DatabaseInterface {
     this._propColMaps = {};
   }
 
+  get baseDatabase (): BaseDatabase {
+    return this.baseDatabase;
+  }
+
   async init (): Promise<void> {
     this._conn = await this._baseDatabase.init();
     {{#if queries}}

--- a/packages/codegen/src/templates/export-state-template.handlebars
+++ b/packages/codegen/src/templates/export-state-template.handlebars
@@ -59,7 +59,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/export-state-template.handlebars
+++ b/packages/codegen/src/templates/export-state-template.handlebars
@@ -59,7 +59,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/fill-template.handlebars
+++ b/packages/codegen/src/templates/fill-template.handlebars
@@ -72,7 +72,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/fill-template.handlebars
+++ b/packages/codegen/src/templates/fill-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import assert from 'assert';
 import 'reflect-metadata';
 import yargs from 'yargs';
@@ -75,7 +72,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/import-state-template.handlebars
+++ b/packages/codegen/src/templates/import-state-template.handlebars
@@ -50,7 +50,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/import-state-template.handlebars
+++ b/packages/codegen/src/templates/import-state-template.handlebars
@@ -50,7 +50,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/index-block-template.handlebars
+++ b/packages/codegen/src/templates/index-block-template.handlebars
@@ -44,7 +44,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/index-block-template.handlebars
+++ b/packages/codegen/src/templates/index-block-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
@@ -47,7 +44,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/inspect-cid-template.handlebars
+++ b/packages/codegen/src/templates/inspect-cid-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import assert from 'assert';
 import yargs from 'yargs';
 import 'reflect-metadata';
@@ -48,7 +45,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/inspect-cid-template.handlebars
+++ b/packages/codegen/src/templates/inspect-cid-template.handlebars
@@ -45,7 +45,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/job-runner-template.handlebars
+++ b/packages/codegen/src/templates/job-runner-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import assert from 'assert';
 import 'reflect-metadata';
 import yargs from 'yargs';
@@ -100,7 +97,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/job-runner-template.handlebars
+++ b/packages/codegen/src/templates/job-runner-template.handlebars
@@ -97,7 +97,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/reset-watcher-template.handlebars
+++ b/packages/codegen/src/templates/reset-watcher-template.handlebars
@@ -41,7 +41,7 @@ export const handler = async (argv: any): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/reset-watcher-template.handlebars
+++ b/packages/codegen/src/templates/reset-watcher-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import debug from 'debug';
 import { MoreThan } from 'typeorm';
 import assert from 'assert';
@@ -44,7 +41,7 @@ export const handler = async (argv: any): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/server-template.handlebars
+++ b/packages/codegen/src/templates/server-template.handlebars
@@ -46,7 +46,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/server-template.handlebars
+++ b/packages/codegen/src/templates/server-template.handlebars
@@ -46,7 +46,7 @@ export const main = async (): Promise<any> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/watch-contract-template.handlebars
+++ b/packages/codegen/src/templates/watch-contract-template.handlebars
@@ -61,7 +61,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/codegen/src/templates/watch-contract-template.handlebars
+++ b/packages/codegen/src/templates/watch-contract-template.handlebars
@@ -2,9 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-{{#if (subgraphPath)}}
-import path from 'path';
-{{/if}}
 import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
@@ -64,7 +61,7 @@ const main = async (): Promise<void> => {
   await db.init();
   {{#if (subgraphPath)}}
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/checkpoint-cmds/create.ts
+++ b/packages/eden-watcher/src/cli/checkpoint-cmds/create.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-import path from 'path';
 import debug from 'debug';
 import assert from 'assert';
 
@@ -38,7 +37,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/checkpoint-cmds/create.ts
+++ b/packages/eden-watcher/src/cli/checkpoint-cmds/create.ts
@@ -37,7 +37,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/checkpoint-cmds/verify.ts
+++ b/packages/eden-watcher/src/cli/checkpoint-cmds/verify.ts
@@ -33,7 +33,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/checkpoint-cmds/verify.ts
+++ b/packages/eden-watcher/src/cli/checkpoint-cmds/verify.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-import path from 'path';
 import debug from 'debug';
 import assert from 'assert';
 
@@ -34,7 +33,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/export-state.ts
+++ b/packages/eden-watcher/src/cli/export-state.ts
@@ -47,7 +47,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/export-state.ts
+++ b/packages/eden-watcher/src/cli/export-state.ts
@@ -47,7 +47,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/import-state.ts
+++ b/packages/eden-watcher/src/cli/import-state.ts
@@ -47,7 +47,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/import-state.ts
+++ b/packages/eden-watcher/src/cli/import-state.ts
@@ -47,7 +47,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/index-block.ts
+++ b/packages/eden-watcher/src/cli/index-block.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-import path from 'path';
 import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
@@ -42,7 +41,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/index-block.ts
+++ b/packages/eden-watcher/src/cli/index-block.ts
@@ -41,7 +41,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/inspect-cid.ts
+++ b/packages/eden-watcher/src/cli/inspect-cid.ts
@@ -42,7 +42,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/inspect-cid.ts
+++ b/packages/eden-watcher/src/cli/inspect-cid.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import assert from 'assert';
 import yargs from 'yargs';
 import 'reflect-metadata';
@@ -43,7 +42,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/eden-watcher/src/cli/reset-cmds/watcher.ts
@@ -2,9 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import debug from 'debug';
-import { MoreThan } from 'typeorm';
 import assert from 'assert';
 
 import { getConfig, initClients, resetJobs, JobQueue } from '@cerc-io/util';
@@ -12,25 +10,6 @@ import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
 import { Database } from '../../database';
 import { Indexer } from '../../indexer';
-import { BlockProgress } from '../../entity/BlockProgress';
-import { Producer } from '../../entity/Producer';
-import { ProducerSet } from '../../entity/ProducerSet';
-import { ProducerSetChange } from '../../entity/ProducerSetChange';
-import { ProducerRewardCollectorChange } from '../../entity/ProducerRewardCollectorChange';
-import { RewardScheduleEntry } from '../../entity/RewardScheduleEntry';
-import { RewardSchedule } from '../../entity/RewardSchedule';
-import { ProducerEpoch } from '../../entity/ProducerEpoch';
-import { Block } from '../../entity/Block';
-import { Epoch } from '../../entity/Epoch';
-import { SlotClaim } from '../../entity/SlotClaim';
-import { Slot } from '../../entity/Slot';
-import { Staker } from '../../entity/Staker';
-import { Network } from '../../entity/Network';
-import { Distributor } from '../../entity/Distributor';
-import { Distribution } from '../../entity/Distribution';
-import { Claim } from '../../entity/Claim';
-import { Slash } from '../../entity/Slash';
-import { Account } from '../../entity/Account';
 
 const log = debug('vulcanize:reset-watcher');
 
@@ -53,7 +32,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/eden-watcher/src/cli/reset-cmds/watcher.ts
@@ -32,7 +32,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/watch-contract.ts
+++ b/packages/eden-watcher/src/cli/watch-contract.ts
@@ -58,7 +58,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/watch-contract.ts
+++ b/packages/eden-watcher/src/cli/watch-contract.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
@@ -59,7 +58,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/database.ts
+++ b/packages/eden-watcher/src/database.ts
@@ -31,6 +31,10 @@ export class Database implements DatabaseInterface {
     this._baseDatabase = new BaseDatabase(this._config);
   }
 
+  get baseDatabase (): BaseDatabase {
+    return this.baseDatabase;
+  }
+
   async init (): Promise<void> {
     this._conn = await this._baseDatabase.init();
   }

--- a/packages/eden-watcher/src/fill.ts
+++ b/packages/eden-watcher/src/fill.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import assert from 'assert';
 import 'reflect-metadata';
 import yargs from 'yargs';
@@ -66,7 +65,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/fill.ts
+++ b/packages/eden-watcher/src/fill.ts
@@ -65,7 +65,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/job-runner.ts
+++ b/packages/eden-watcher/src/job-runner.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import assert from 'assert';
 import 'reflect-metadata';
 import yargs from 'yargs';
@@ -95,7 +94,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/job-runner.ts
+++ b/packages/eden-watcher/src/job-runner.ts
@@ -94,7 +94,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/server.ts
+++ b/packages/eden-watcher/src/server.ts
@@ -14,7 +14,7 @@ import debug from 'debug';
 import 'graphql-import-node';
 import { createServer } from 'http';
 
-import { DEFAULT_CONFIG_PATH, getConfig, Config, JobQueue, KIND_ACTIVE, initClients, startGQLMetricsServer, resetJobs } from '@cerc-io/util';
+import { DEFAULT_CONFIG_PATH, getConfig, Config, JobQueue, KIND_ACTIVE, initClients, startGQLMetricsServer } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
 import { createResolvers } from './resolvers';
@@ -43,7 +43,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-node/src/cli/compare/compare-blocks.ts
+++ b/packages/graph-node/src/cli/compare/compare-blocks.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import assert from 'assert';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import _ from 'lodash';
-import { getConfig as getWatcherConfig, wait } from '@cerc-io/util';
+import { getConfig as getWatcherConfig, wait, Database as BaseDatabase } from '@cerc-io/util';
 import { GraphQLClient } from '@cerc-io/ipld-eth-client';
 
 import {
@@ -123,7 +123,11 @@ export const main = async (): Promise<void> => {
     const watcherConfigPath = path.resolve(path.dirname(configFile), config.watcher.configPath);
     const entitiesDir = path.resolve(path.dirname(configFile), config.watcher.entitiesDir);
     const watcherConfig = await getWatcherConfig(watcherConfigPath);
-    db = new Database(watcherConfig.database, entitiesDir);
+
+    const baseDatabase = new BaseDatabase({ ...watcherConfig.database, entities: [entitiesDir] });
+    await baseDatabase.init();
+
+    db = new Database(baseDatabase);
     await db.init();
 
     if (config.watcher.verifyState) {

--- a/packages/graph-node/src/database.ts
+++ b/packages/graph-node/src/database.ts
@@ -61,7 +61,6 @@ interface CachedEntities {
 }
 
 export class Database {
-  _config: ConnectionOptions
   _conn!: Connection
   _baseDatabase: BaseDatabase
   _entityQueryTypeMap: Map<new() => any, ENTITY_QUERY_TYPE>
@@ -71,16 +70,8 @@ export class Database {
     latestPrunedEntities: new Map()
   }
 
-  constructor (config: ConnectionOptions, entitiesPath: string, entityQueryTypeMap: Map<new() => any, ENTITY_QUERY_TYPE> = new Map()) {
-    assert(config);
-
-    this._config = {
-      name: 'subgraph',
-      ...config,
-      entities: [entitiesPath]
-    };
-
-    this._baseDatabase = new BaseDatabase(this._config);
+  constructor (baseDatabase: BaseDatabase, entityQueryTypeMap: Map<new() => any, ENTITY_QUERY_TYPE> = new Map()) {
+    this._baseDatabase = baseDatabase;
     this._entityQueryTypeMap = entityQueryTypeMap;
   }
 
@@ -89,7 +80,8 @@ export class Database {
   }
 
   async init (): Promise<void> {
-    this._conn = await this._baseDatabase.init();
+    this._conn = this._baseDatabase.conn;
+    assert(this._conn);
   }
 
   async close (): Promise<void> {

--- a/packages/graph-node/test/utils/index.ts
+++ b/packages/graph-node/test/utils/index.ts
@@ -3,7 +3,7 @@
 //
 
 import { BaseProvider } from '@ethersproject/providers';
-import { getCustomProvider } from '@cerc-io/util';
+import { getCustomProvider, Database as BaseDatabase } from '@cerc-io/util';
 import { EthClient } from '@cerc-io/ipld-eth-client';
 import { StorageLayout } from '@cerc-io/solidity-mapper';
 
@@ -71,7 +71,8 @@ export const getDummyGraphData = (): any => {
 };
 
 export const getTestDatabase = (): Database => {
-  return new Database({ type: 'postgres' }, '');
+  const baseDatabase = new BaseDatabase({ type: 'postgres' });
+  return new Database(baseDatabase);
 };
 
 export const getTestIndexer = (storageLayout?: Map<string, StorageLayout>): Indexer => {

--- a/packages/graph-test-watcher/src/cli/checkpoint-cmds/create.ts
+++ b/packages/graph-test-watcher/src/cli/checkpoint-cmds/create.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-import path from 'path';
 import debug from 'debug';
 import assert from 'assert';
 
@@ -38,7 +37,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/checkpoint-cmds/create.ts
+++ b/packages/graph-test-watcher/src/cli/checkpoint-cmds/create.ts
@@ -37,7 +37,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/checkpoint-cmds/verify.ts
+++ b/packages/graph-test-watcher/src/cli/checkpoint-cmds/verify.ts
@@ -33,7 +33,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/checkpoint-cmds/verify.ts
+++ b/packages/graph-test-watcher/src/cli/checkpoint-cmds/verify.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-import path from 'path';
 import debug from 'debug';
 import assert from 'assert';
 
@@ -34,7 +33,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/export-state.ts
+++ b/packages/graph-test-watcher/src/cli/export-state.ts
@@ -47,7 +47,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/export-state.ts
+++ b/packages/graph-test-watcher/src/cli/export-state.ts
@@ -47,7 +47,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/import-state.ts
+++ b/packages/graph-test-watcher/src/cli/import-state.ts
@@ -47,7 +47,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/import-state.ts
+++ b/packages/graph-test-watcher/src/cli/import-state.ts
@@ -47,7 +47,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/index-block.ts
+++ b/packages/graph-test-watcher/src/cli/index-block.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 Vulcanize, Inc.
 //
 
-import path from 'path';
 import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
@@ -42,7 +41,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/index-block.ts
+++ b/packages/graph-test-watcher/src/cli/index-block.ts
@@ -41,7 +41,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/inspect-cid.ts
+++ b/packages/graph-test-watcher/src/cli/inspect-cid.ts
@@ -42,7 +42,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/inspect-cid.ts
+++ b/packages/graph-test-watcher/src/cli/inspect-cid.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import assert from 'assert';
 import yargs from 'yargs';
 import 'reflect-metadata';
@@ -43,7 +42,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/graph-test-watcher/src/cli/reset-cmds/watcher.ts
@@ -2,9 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import debug from 'debug';
-import { MoreThan } from 'typeorm';
 import assert from 'assert';
 
 import { getConfig, initClients, resetJobs, JobQueue } from '@cerc-io/util';
@@ -12,13 +10,6 @@ import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
 import { Database } from '../../database';
 import { Indexer } from '../../indexer';
-import { BlockProgress } from '../../entity/BlockProgress';
-
-import { GetMethod } from '../../entity/GetMethod';
-import { _Test } from '../../entity/_Test';
-import { Author } from '../../entity/Author';
-import { Blog } from '../../entity/Blog';
-import { Category } from '../../entity/Category';
 
 const log = debug('vulcanize:reset-watcher');
 
@@ -41,7 +32,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/graph-test-watcher/src/cli/reset-cmds/watcher.ts
@@ -32,7 +32,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/watch-contract.ts
+++ b/packages/graph-test-watcher/src/cli/watch-contract.ts
@@ -58,7 +58,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/cli/watch-contract.ts
+++ b/packages/graph-test-watcher/src/cli/watch-contract.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
@@ -59,7 +58,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, '../entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/database.ts
+++ b/packages/graph-test-watcher/src/database.ts
@@ -36,6 +36,10 @@ export class Database implements DatabaseInterface {
     this._propColMaps = {};
   }
 
+  get baseDatabase (): BaseDatabase {
+    return this.baseDatabase;
+  }
+
   async init (): Promise<void> {
     this._conn = await this._baseDatabase.init();
     this._setPropColMaps();

--- a/packages/graph-test-watcher/src/fill.ts
+++ b/packages/graph-test-watcher/src/fill.ts
@@ -59,7 +59,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/fill.ts
+++ b/packages/graph-test-watcher/src/fill.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import assert from 'assert';
 import 'reflect-metadata';
 import yargs from 'yargs';
@@ -60,7 +59,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/job-runner.ts
+++ b/packages/graph-test-watcher/src/job-runner.ts
@@ -2,7 +2,6 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import path from 'path';
 import assert from 'assert';
 import 'reflect-metadata';
 import yargs from 'yargs';
@@ -95,7 +94,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/job-runner.ts
+++ b/packages/graph-test-watcher/src/job-runner.ts
@@ -94,7 +94,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/server.ts
+++ b/packages/graph-test-watcher/src/server.ts
@@ -43,7 +43,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.database, path.resolve(__dirname, 'entity/*'));
+  const graphDb = new GraphDatabase(db._baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-test-watcher/src/server.ts
+++ b/packages/graph-test-watcher/src/server.ts
@@ -43,7 +43,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(db._baseDatabase);
+  const graphDb = new GraphDatabase(db.baseDatabase);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -86,6 +86,10 @@ export class Database {
     });
   }
 
+  get conn (): Connection {
+    return this._conn;
+  }
+
   async init (): Promise<Connection> {
     assert(!this._conn);
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/151

- Avoid creating a separate base database instance when constructing a graph database
- Update usage in watchers and `codegen`