### PR TITLE
Latest entity queries to optimize frontend app GQL requests

### DIFF
--- a/packages/eden-watcher/src/database.ts
+++ b/packages/eden-watcher/src/database.ts
@@ -44,7 +44,8 @@ export class Database implements DatabaseInterface {
 
     this._config = {
       ...config,
-      entities: [path.join(__dirname, 'entity/*')]
+      entities: [path.join(__dirname, 'entity/*')],
+      subscribers: [path.join(__dirname, 'entity/Subscriber.*')]
     };
 
     this._baseDatabase = new BaseDatabase(this._config);

--- a/packages/eden-watcher/src/entity/Subscriber.ts
+++ b/packages/eden-watcher/src/entity/Subscriber.ts
@@ -4,9 +4,10 @@
 
 import { EventSubscriber, EntitySubscriberInterface, InsertEvent, UpdateEvent } from 'typeorm';
 
+import { afterEntityInsertOrUpdate } from '@cerc-io/graph-node';
+
 import { FrothyEntity } from './FrothyEntity';
 import { ENTITIES } from '../database';
-import { afterEntityInsertOrUpdate } from '@cerc-io/graph-node';
 
 @EventSubscriber()
 export class EntitySubscriber implements EntitySubscriberInterface {

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -788,20 +788,29 @@ export class Database {
     return repo.save(entity);
   }
 
-  buildQuery<Entity> (repo: Repository<Entity>, selectQueryBuilder: SelectQueryBuilder<Entity>, where: Where = {}): SelectQueryBuilder<Entity> {
+  buildQuery<Entity> (
+    repo: Repository<Entity>,
+    selectQueryBuilder: SelectQueryBuilder<Entity>,
+    where: Where = {},
+    alias?: string
+  ): SelectQueryBuilder<Entity> {
+    if (!alias) {
+      alias = selectQueryBuilder.alias;
+    }
+
     Object.entries(where).forEach(([field, filters]) => {
       filters.forEach((filter, index) => {
         // Form the where clause.
         let { not, operator, value } = filter;
         const columnMetadata = repo.metadata.findColumnWithPropertyName(field);
         assert(columnMetadata);
-        let whereClause = `"${selectQueryBuilder.alias}"."${columnMetadata.databaseName}" `;
+        let whereClause = `"${alias}"."${columnMetadata.databaseName}" `;
 
         if (columnMetadata.relationMetadata) {
           // For relation fields, use the id column.
           const idColumn = columnMetadata.relationMetadata.joinColumns.find(column => column.referencedColumn?.propertyName === 'id');
           assert(idColumn);
-          whereClause = `"${selectQueryBuilder.alias}"."${idColumn.databaseName}" `;
+          whereClause = `"${alias}"."${idColumn.databaseName}" `;
         }
 
         if (not) {
@@ -853,8 +862,13 @@ export class Database {
     repo: Repository<Entity>,
     selectQueryBuilder: SelectQueryBuilder<Entity>,
     orderOptions: { orderBy?: string, orderDirection?: string },
-    columnPrefix = ''
+    columnPrefix = '',
+    alias?: string
   ): SelectQueryBuilder<Entity> {
+    if (!alias) {
+      alias = selectQueryBuilder.alias;
+    }
+
     const { orderBy, orderDirection } = orderOptions;
     assert(orderBy);
 
@@ -862,7 +876,7 @@ export class Database {
     assert(columnMetadata);
 
     return selectQueryBuilder.addOrderBy(
-      `"${selectQueryBuilder.alias}"."${columnPrefix}${columnMetadata.databaseName}"`,
+      `"${alias}"."${columnPrefix}${columnMetadata.databaseName}"`,
       orderDirection === 'desc' ? 'DESC' : 'ASC'
     );
   }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191
Follows https://github.com/vulcanize/uniswap-watcher-ts/pull/383

- Implemented queries to get result from table containing latest entities
- Add typeorm subscriber to update latest entities
