### PR TITLE
Reset latest and frothy entity tables on watcher reset

### DIFF
--- a/packages/eden-watcher/src/cli/checkpoint-cmds/create.ts
+++ b/packages/eden-watcher/src/cli/checkpoint-cmds/create.ts
@@ -8,7 +8,7 @@ import assert from 'assert';
 import { getConfig, initClients, JobQueue, Config } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from '../../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../../database';
 import { Indexer } from '../../indexer';
 
 const log = debug('vulcanize:checkpoint-create');
@@ -37,7 +37,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/checkpoint-cmds/verify.ts
+++ b/packages/eden-watcher/src/cli/checkpoint-cmds/verify.ts
@@ -8,7 +8,7 @@ import assert from 'assert';
 import { getConfig, initClients, JobQueue, Config, verifyCheckpointData } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from '../../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../../database';
 import { Indexer } from '../../indexer';
 
 const log = debug('vulcanize:checkpoint-verify');
@@ -33,7 +33,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/export-state.ts
+++ b/packages/eden-watcher/src/cli/export-state.ts
@@ -13,7 +13,7 @@ import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue, StateKin
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 import * as codec from '@ipld/dag-cbor';
 
-import { Database } from '../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
 import { Indexer } from '../indexer';
 
 const log = debug('vulcanize:export-state');
@@ -47,7 +47,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/import-state.ts
+++ b/packages/eden-watcher/src/cli/import-state.ts
@@ -15,7 +15,7 @@ import { getConfig, fillBlocks, JobQueue, DEFAULT_CONFIG_PATH, Config, initClien
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 import * as codec from '@ipld/dag-cbor';
 
-import { Database } from '../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
 import { Indexer } from '../indexer';
 import { EventWatcher } from '../events';
 import { State } from '../entity/State';
@@ -47,7 +47,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/index-block.ts
+++ b/packages/eden-watcher/src/cli/index-block.ts
@@ -10,7 +10,7 @@ import assert from 'assert';
 import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue, indexBlock } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from '../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
 import { Indexer } from '../indexer';
 
 const log = debug('vulcanize:index-block');
@@ -41,7 +41,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/inspect-cid.ts
+++ b/packages/eden-watcher/src/cli/inspect-cid.ts
@@ -11,7 +11,7 @@ import util from 'util';
 import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from '../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
 import { Indexer } from '../indexer';
 
 const log = debug('vulcanize:inspect-cid');
@@ -42,7 +42,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/eden-watcher/src/cli/reset-cmds/watcher.ts
@@ -8,7 +8,7 @@ import assert from 'assert';
 import { getConfig, initClients, resetJobs, JobQueue } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from '../../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../../database';
 import { Indexer } from '../../indexer';
 
 const log = debug('vulcanize:reset-watcher');
@@ -32,7 +32,7 @@ export const handler = async (argv: any): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);
@@ -53,5 +53,6 @@ export const handler = async (argv: any): Promise<void> => {
   await graphWatcher.init();
 
   await indexer.resetWatcherToBlock(argv.blockNumber);
+  await indexer.resetLatestEntities(argv.blockNumber);
   log('Reset watcher successfully');
 };

--- a/packages/eden-watcher/src/cli/watch-contract.ts
+++ b/packages/eden-watcher/src/cli/watch-contract.ts
@@ -10,7 +10,7 @@ import assert from 'assert';
 import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from '../database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
 import { Indexer } from '../indexer';
 
 const log = debug('vulcanize:watch-contract');
@@ -58,7 +58,7 @@ const main = async (): Promise<void> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/database.ts
+++ b/packages/eden-watcher/src/database.ts
@@ -34,6 +34,8 @@ import { Staker } from './entity/Staker';
 
 export const ENTITIES = new Set([Account, Claim, Distribution, Distributor, Epoch, Network, Producer, ProducerEpoch, ProducerRewardCollectorChange, ProducerSet, ProducerSetChange, RewardSchedule, RewardScheduleEntry, Slash, Slot, SlotClaim, Staker]);
 
+export const ENTITY_TO_LATEST_ENTITY_MAP: Map<any, any> = new Map();
+
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions;
   _conn!: Connection;

--- a/packages/eden-watcher/src/entity/Subscriber.ts
+++ b/packages/eden-watcher/src/entity/Subscriber.ts
@@ -7,15 +7,15 @@ import { EventSubscriber, EntitySubscriberInterface, InsertEvent, UpdateEvent } 
 import { afterEntityInsertOrUpdate } from '@cerc-io/graph-node';
 
 import { FrothyEntity } from './FrothyEntity';
-import { ENTITIES } from '../database';
+import { ENTITIES, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
 
 @EventSubscriber()
 export class EntitySubscriber implements EntitySubscriberInterface {
   async afterInsert (event: InsertEvent<any>): Promise<void> {
-    await afterEntityInsertOrUpdate(FrothyEntity, ENTITIES, event);
+    await afterEntityInsertOrUpdate(FrothyEntity, ENTITIES, event, ENTITY_TO_LATEST_ENTITY_MAP);
   }
 
   async afterUpdate (event: UpdateEvent<any>): Promise<void> {
-    await afterEntityInsertOrUpdate(FrothyEntity, ENTITIES, event);
+    await afterEntityInsertOrUpdate(FrothyEntity, ENTITIES, event, ENTITY_TO_LATEST_ENTITY_MAP);
   }
 }

--- a/packages/eden-watcher/src/fill.ts
+++ b/packages/eden-watcher/src/fill.ts
@@ -12,7 +12,7 @@ import { PubSub } from 'graphql-subscriptions';
 import { Config, getConfig, fillBlocks, JobQueue, DEFAULT_CONFIG_PATH, initClients } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
-import { Database } from './database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from './database';
 import { Indexer } from './indexer';
 import { EventWatcher } from './events';
 import { fillState } from './fill-state';
@@ -65,7 +65,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/indexer.ts
+++ b/packages/eden-watcher/src/indexer.ts
@@ -489,6 +489,10 @@ export class Indexer implements IndexerInterface {
     await this._graphWatcher.pruneFrothyEntities(FrothyEntity, blockNumber);
   }
 
+  async resetLatestEntities (blockNumber: number): Promise<void> {
+    await this._graphWatcher.resetLatestEntities(blockNumber);
+  }
+
   async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     return this._baseIndexer.updateBlockProgress(block, lastProcessedEventIndex);
   }

--- a/packages/eden-watcher/src/job-runner.ts
+++ b/packages/eden-watcher/src/job-runner.ts
@@ -25,7 +25,7 @@ import {
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
 import { Indexer } from './indexer';
-import { Database } from './database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from './database';
 
 const log = debug('vulcanize:job-runner');
 
@@ -94,7 +94,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/eden-watcher/src/server.ts
+++ b/packages/eden-watcher/src/server.ts
@@ -18,7 +18,7 @@ import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
 import { createResolvers } from './resolvers';
 import { Indexer } from './indexer';
-import { Database } from './database';
+import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from './database';
 import { EventWatcher } from './events';
 
 const log = debug('vulcanize:server');
@@ -42,7 +42,7 @@ export const main = async (): Promise<any> => {
   const db = new Database(config.database);
   await db.init();
 
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
+  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
   await graphDb.init();
 
   const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -386,6 +386,20 @@ export class GraphWatcher {
     }
   }
 
+  async resetLatestEntities (blockNumber: number): Promise<void> {
+    const dbTx = await this._database.createTransactionRunner();
+    try {
+      await this._database.resetLatestEntities(dbTx, blockNumber);
+
+      dbTx.commitTransaction();
+    } catch (error) {
+      await dbTx.rollbackTransaction();
+      throw error;
+    } finally {
+      await dbTx.release();
+    }
+  }
+
   pruneEntityCacheFrothyBlocks (canonicalBlockHash: string, canonicalBlockNumber: number) {
     this._database.pruneEntityCacheFrothyBlocks(canonicalBlockHash, canonicalBlockNumber);
   }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191
Follows https://github.com/cerc-io/watcher-ts/pull/235