### PR TITLE
Accomodate GQL requests caching in code generator

### DIFF
--- a/packages/address-watcher/src/server.ts
+++ b/packages/address-watcher/src/server.ts
@@ -39,8 +39,6 @@ export const main = async (): Promise<any> => {
 
   assert(config.server, 'Missing server config');
 
-  const { host, port } = config.server;
-
   const { upstream, database: dbConfig, jobQueue: jobQueueConfig } = config;
 
   assert(dbConfig, 'Missing database config');
@@ -82,7 +80,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServer(app, typeDefs, resolvers, { host, port });
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   return { app, server };
 };

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -30,6 +30,19 @@
   # Use -1 for skipping check on block range.
   maxEventsBlockRange = 1000
 
+  # GQL cache settings
+  [server.gqlCache]
+    enabled = true
+
+    # Max in-memory cache size (in bytes) (default 8 MB)
+    # maxCacheSize
+
+    # GQL cache-control max-age settings (in seconds)
+    maxAge = 15
+    {{#if (subgraphPath)}}
+    timeTravelMaxAge = 86400 # 1 day
+    {{/if}}
+
 [metrics]
   host = "127.0.0.1"
   port = 9000

--- a/packages/codegen/src/templates/readme-template.handlebars
+++ b/packages/codegen/src/templates/readme-template.handlebars
@@ -59,6 +59,18 @@
 
   * Edit the custom hook function `createStateCheckpoint` (triggered just before default and CLI checkpoint) in [hooks.ts](./src/hooks.ts) to save the state in a `checkpoint` `State` using the `Indexer` object.
 
+### GQL Caching
+
+To enable GQL requests caching:
+
+* Update the `server.gqlCache` config with required settings.
+
+* In the GQL [schema file](./src/schema.gql), use the `cacheControl` directive to apply cache hints at schema level.
+
+  * Eg. Set `inheritMaxAge` to true for non-scalar fields of a type.
+
+* In the GQL [resolvers file](./src/resolvers.ts), uncomment the `setGQLCacheHints()` calls in resolvers for required queries.
+
 ## Run
 
 * Run the watcher:

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -8,7 +8,7 @@ import debug from 'debug';
 import Decimal from 'decimal.js';
 import { GraphQLResolveInfo, GraphQLScalarType } from 'graphql';
 
-import { ValueResult, BlockHeight, gqlTotalQueryCount, gqlQueryCount, jsonBigIntStringReplacer, getResultState } from '@cerc-io/util';
+import { ValueResult, BlockHeight, gqlTotalQueryCount, gqlQueryCount, jsonBigIntStringReplacer, getResultState, setGQLCacheHints } from '@cerc-io/util';
 
 import { Indexer } from './indexer';
 import { EventWatcher } from './events';
@@ -21,6 +21,8 @@ const log = debug('vulcanize:resolver');
 
 export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatcher): Promise<any> => {
   assert(indexer);
+
+  const gqlCacheConfig = indexer.serverConfig.gqlCache;
 
   return {
     BigInt: new BigInt('bigInt'),
@@ -63,13 +65,21 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
     Query: {
       {{#each queries}}
-      {{this.name}}: (_: any, { blockHash, contractAddress
-      {{~#each this.params}}, {{this.name~}} {{/each}} }: { blockHash: string, contractAddress: string
-      {{~#each this.params}}, {{this.name}}: {{this.type~}} {{/each}} }): Promise<ValueResult> => {
+      {{this.name}}: (
+        _: any,
+        { blockHash, contractAddress
+        {{~#each this.params}}, {{this.name~}} {{/each}} }: { blockHash: string, contractAddress: string
+        {{~#each this.params}}, {{this.name}}: {{this.type~}} {{/each}} },
+        __: any,
+        info: GraphQLResolveInfo
+      ): Promise<ValueResult> => {
         log('{{this.name}}', blockHash, contractAddress
         {{~#each this.params}}, {{this.name~}} {{/each}});
         gqlTotalQueryCount.inc(1);
         gqlQueryCount.labels('{{this.name}}').inc(1);
+
+        // Set cache-control hints
+        // setGQLCacheHints(info, {}, gqlCacheConfig);
 
         return indexer.{{this.name}}(blockHash, contractAddress
         {{~#each this.params}}, {{this.name~}} {{/each}});
@@ -79,7 +89,7 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       {{~#each subgraphQueries}}
       {{this.queryName}}: async (
-         _: any,
+        _: any,
         { id, block = {} }: { id: string, block: BlockHeight },
         __: any,
         info: GraphQLResolveInfo
@@ -88,6 +98,9 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
         gqlTotalQueryCount.inc(1);
         gqlQueryCount.labels('{{this.queryName}}').inc(1);
         assert(info.fieldNodes[0].selectionSet);
+
+        // Set cache-control hints
+        // setGQLCacheHints(info, block, gqlCacheConfig);
 
         return indexer.getSubgraphEntity({{this.entityName}}, id, block, info.fieldNodes[0].selectionSet.selections);
       },

--- a/packages/codegen/src/templates/server-template.handlebars
+++ b/packages/codegen/src/templates/server-template.handlebars
@@ -39,7 +39,7 @@ export const main = async (): Promise<any> => {
   const config: Config = await getConfig(argv.f);
   const { ethClient, ethProvider } = await initClients(config);
 
-  const { host, port, kind: watcherKind } = config.server;
+  const { kind: watcherKind } = config.server;
 
   const db = new Database(config.database);
   await db.init();
@@ -85,7 +85,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServer(app, typeDefs, resolvers, { host, port });
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   startGQLMetricsServer(config);
 

--- a/packages/eden-watcher/src/server.ts
+++ b/packages/eden-watcher/src/server.ts
@@ -13,7 +13,7 @@ import { hideBin } from 'yargs/helpers';
 import debug from 'debug';
 import 'graphql-import-node';
 
-import { DEFAULT_CONFIG_PATH, getConfig, Config, JobQueue, KIND_ACTIVE, initClients, startGQLMetricsServer, createAndStartServerWithCache } from '@cerc-io/util';
+import { DEFAULT_CONFIG_PATH, getConfig, Config, JobQueue, KIND_ACTIVE, initClients, startGQLMetricsServer, createAndStartServer } from '@cerc-io/util';
 import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
 
 import { createResolvers } from './resolvers';
@@ -79,7 +79,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServerWithCache(app, typeDefs, resolvers, config.server);
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   startGQLMetricsServer(config);
 

--- a/packages/erc20-watcher/src/server.ts
+++ b/packages/erc20-watcher/src/server.ts
@@ -37,7 +37,7 @@ export const main = async (): Promise<any> => {
   const config: Config = await getConfig(argv.f);
   const { ethClient, ethProvider } = await initClients(config);
 
-  const { host, port, kind: watcherKind } = config.server;
+  const { kind: watcherKind } = config.server;
 
   const db = new Database(config.database);
   await db.init();
@@ -70,7 +70,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServer(app, typeDefs, resolvers, { host, port });
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   return { app, server };
 };

--- a/packages/erc721-watcher/src/server.ts
+++ b/packages/erc721-watcher/src/server.ts
@@ -36,7 +36,7 @@ export const main = async (): Promise<any> => {
   const config: Config = await getConfig(argv.f);
   const { ethClient, ethProvider } = await initClients(config);
 
-  const { host, port, kind: watcherKind } = config.server;
+  const { kind: watcherKind } = config.server;
 
   const db = new Database(config.database);
   await db.init();
@@ -70,7 +70,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServer(app, typeDefs, resolvers, { host, port });
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   return { app, server };
 };

--- a/packages/graph-test-watcher/src/server.ts
+++ b/packages/graph-test-watcher/src/server.ts
@@ -37,7 +37,7 @@ export const main = async (): Promise<any> => {
   const config: Config = await getConfig(argv.f);
   const { ethClient, ethProvider } = await initClients(config);
 
-  const { host, port, kind: watcherKind } = config.server;
+  const { kind: watcherKind } = config.server;
 
   const db = new Database(config.database);
   await db.init();
@@ -79,7 +79,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServer(app, typeDefs, resolvers, { host, port });
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   return { app, server };
 };

--- a/packages/mobymask-watcher/src/server.ts
+++ b/packages/mobymask-watcher/src/server.ts
@@ -36,7 +36,7 @@ export const main = async (): Promise<any> => {
   const config: Config = await getConfig(argv.f);
   const { ethClient, ethProvider } = await initClients(config);
 
-  const { host, port, kind: watcherKind } = config.server;
+  const { kind: watcherKind } = config.server;
 
   const db = new Database(config.database);
   await db.init();
@@ -70,7 +70,7 @@ export const main = async (): Promise<any> => {
 
   // Create an Express app
   const app: Application = express();
-  const server = createAndStartServer(app, typeDefs, resolvers, { host, port });
+  const server = createAndStartServer(app, typeDefs, resolvers, config.server);
 
   startGQLMetricsServer(config);
 

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -15,6 +15,7 @@
     "decimal.js": "^10.3.1",
     "ethers": "^5.4.4",
     "express": "^4.18.2",
+    "express-queue": "^0.0.13",
     "fs-extra": "^10.0.0",
     "graphql": "^15.5.0",
     "graphql-ws": "^5.11.2",

--- a/packages/util/src/misc.ts
+++ b/packages/util/src/misc.ts
@@ -296,9 +296,14 @@ export const setGQLCacheHints = (info: GraphQLResolveInfo, block: BlockHeight, g
     return;
   }
 
-  assert(gqlCache.maxAge, 'Missing server gqlCache.maxAge');
-  assert(gqlCache.timeTravelMaxAge, 'Missing server gqlCache.timeTravelMaxAge');
+  let maxAge: number;
+  if (_.isEmpty(block)) {
+    assert(gqlCache.maxAge, 'Missing server gqlCache.maxAge');
+    maxAge = gqlCache.maxAge;
+  } else {
+    assert(gqlCache.timeTravelMaxAge, 'Missing server gqlCache.timeTravelMaxAge');
+    maxAge = gqlCache.timeTravelMaxAge;
+  }
 
-  const maxAge = _.isEmpty(block) ? gqlCache.maxAge : gqlCache.timeTravelMaxAge;
   info.cacheControl.setCacheHint({ maxAge });
 };

--- a/packages/util/src/server.ts
+++ b/packages/util/src/server.ts
@@ -7,6 +7,7 @@ import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
 import debug from 'debug';
 import responseCachePlugin from 'apollo-server-plugin-response-cache';
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
+import queue from 'express-queue';
 
 import { TypeSource } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
@@ -22,9 +23,9 @@ export const createAndStartServer = async (
   resolvers: any,
   serverConfig: ServerConfig
 ): Promise<ApolloServer> => {
-  const host = serverConfig.host;
-  const port = serverConfig.port;
-  const gqlCacheConfig = serverConfig.gqlCache;
+  const { host, port, gqlCache: gqlCacheConfig, maxSimultaneousRequests, maxRequestQueueLimit } = serverConfig;
+
+  app.use(queue({ activeLimit: maxSimultaneousRequests || 1, queuedLimit: maxRequestQueueLimit || -1 }));
 
   // Create HTTP server
   const httpServer = createServer(app);

--- a/packages/util/src/types/common/main.d.ts
+++ b/packages/util/src/types/common/main.d.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2022 Vulcanize, Inc.
+//
+
+// https://medium.com/@steveruiz/using-a-javascript-library-without-type-declarations-in-a-typescript-project-3643490015f3
+declare module 'express-queue';

--- a/packages/util/src/types/common/package.json
+++ b/packages/util/src/types/common/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "common",
+  "version": "0.1.0",
+  "license": "AGPL-3.0",
+  "typings": "main.d.ts"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5660,7 +5660,7 @@ debug@4, debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-debug@4.3.4, debug@^4.3.3:
+debug@4.3.4, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -7072,6 +7072,22 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+express-end@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/express-end/-/express-end-0.0.8.tgz#0c8fd95428932158f2b4cf91f4045346bf2c5323"
+  integrity sha512-PPntzICAq006LBpXKBVJtmRUiCRqTMZ+OB8L2RFXgx+OmkMWU66IL4DTEPF/DOcxmsuC7Y0NdbT2R71lb+pBpg==
+  dependencies:
+    debug "^2.2.0"
+
+express-queue@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/express-queue/-/express-queue-0.0.13.tgz#e9800d67749d4dfab7c34223f00595af933ce5df"
+  integrity sha512-C4OEDasGDqpXLrZICSUxbY47p5c0bKqf/3/3hwauSCmI+jVVxKBWU2w39BuKLP6nF65z87uDFBbJMPAn2ZrG3g==
+  dependencies:
+    debug "^4.3.4"
+    express-end "0.0.8"
+    mini-queue "0.0.14"
 
 express@^4.14.0:
   version "4.17.1"
@@ -10370,6 +10386,13 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-queue@0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/mini-queue/-/mini-queue-0.0.14.tgz#83d2f3f908e3cac5390bd986d1e6fbbfa0d95b93"
+  integrity sha512-DNh9Wn8U1jrmn1yVfpviwClyER/Y4ltgGbG+LF/KIdKJ8BEo2Q9jDDPG7tEhz6F/DTZ/ohv5D7AAXFVSFyP05Q==
+  dependencies:
+    debug "^3.1.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191
Follows https://github.com/vulcanize/uniswap-watcher-ts/pull/393, https://github.com/cerc-io/watcher-ts/pull/234 and https://github.com/vulcanize/uniswap-watcher-ts/pull/382

- Add changes for caching GQL requests in code generator
- Add GQL API request queuing