### PR TITLE
Refactor inspect-cid CLI to cli package

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,3 +6,4 @@ export * from './watch-contract';
 export * from './reset/watcher';
 export * from './reset/state';
 export * from './checkpoint/create';
+export * from './inspect-cid';

--- a/packages/cli/src/inspect-cid.ts
+++ b/packages/cli/src/inspect-cid.ts
@@ -1,0 +1,103 @@
+//
+// Copyright 2022 Vulcanize, Inc.
+//
+
+import debug from 'debug';
+import yargs from 'yargs';
+import 'reflect-metadata';
+import assert from 'assert';
+import { ConnectionOptions } from 'typeorm';
+import util from 'util';
+
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { GraphWatcher } from '@cerc-io/graph-node';
+import {
+  DEFAULT_CONFIG_PATH,
+  JobQueue,
+  DatabaseInterface,
+  IndexerInterface,
+  ServerConfig,
+  Clients
+} from '@cerc-io/util';
+
+import { BaseCmd } from './base';
+
+const log = debug('vulcanize:inspect-cid');
+
+interface Arguments {
+  configFile: string;
+  cid: string;
+}
+
+export class InspectCIDCmd {
+  _argv?: Arguments
+  _baseCmd: BaseCmd;
+  _database?: DatabaseInterface;
+  _indexer?: IndexerInterface;
+
+  constructor () {
+    this._baseCmd = new BaseCmd();
+  }
+
+  async initConfig<ConfigType> (): Promise<ConfigType> {
+    this._argv = this._getArgv();
+    assert(this._argv);
+
+    return this._baseCmd.initConfig(this._argv.configFile);
+  }
+
+  async init (
+    Database: new (
+      config: ConnectionOptions,
+      serverConfig?: ServerConfig
+    ) => DatabaseInterface,
+    Indexer: new (
+      serverConfig: ServerConfig,
+      db: DatabaseInterface,
+      clients: Clients,
+      ethProvider: JsonRpcProvider,
+      jobQueue: JobQueue,
+      graphWatcher?: GraphWatcher
+    ) => IndexerInterface,
+    clients: { [key: string]: any } = {}
+  ): Promise<void> {
+    await this.initConfig();
+
+    ({ database: this._database, indexer: this._indexer } = await this._baseCmd.init(Database, Indexer, clients));
+  }
+
+  async exec (): Promise<void> {
+    assert(this._argv);
+    assert(this._database);
+    assert(this._indexer);
+
+    const state = await this._indexer.getStateByCID(this._argv.cid);
+    assert(state, 'State for the provided CID doesn\'t exist.');
+
+    const stateData = await this._indexer.getStateData(state);
+    log(util.inspect(stateData, false, null));
+
+    await this._database.close();
+  }
+
+  _getArgv (): any {
+    return yargs.parserConfiguration({
+      'parse-numbers': false
+    }).options({
+      configFile: {
+        alias: 'f',
+        type: 'string',
+        require: true,
+        demandOption: true,
+        describe: 'Configuration file path (toml)',
+        default: DEFAULT_CONFIG_PATH
+      },
+      cid: {
+        alias: 'c',
+        type: 'string',
+        demandOption: true,
+        describe: 'CID to be inspected'
+      }
+    }).argv;
+  }
+}

--- a/packages/eden-watcher/src/cli/inspect-cid.ts
+++ b/packages/eden-watcher/src/cli/inspect-cid.ts
@@ -2,72 +2,21 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import assert from 'assert';
-import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
-import util from 'util';
 
-import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue } from '@cerc-io/util';
-import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
+import { InspectCIDCmd } from '@cerc-io/cli';
 
-import { Database, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';
+import { Database } from '../database';
 import { Indexer } from '../indexer';
 
 const log = debug('vulcanize:inspect-cid');
 
 const main = async (): Promise<void> => {
-  const argv = await yargs.parserConfiguration({
-    'parse-numbers': false
-  }).options({
-    configFile: {
-      alias: 'f',
-      type: 'string',
-      require: true,
-      demandOption: true,
-      describe: 'Configuration file path (toml)',
-      default: DEFAULT_CONFIG_PATH
-    },
-    cid: {
-      alias: 'c',
-      type: 'string',
-      demandOption: true,
-      describe: 'CID to be inspected'
-    }
-  }).argv;
+  const inspectCIDCmd = new InspectCIDCmd();
+  await inspectCIDCmd.init(Database, Indexer);
 
-  const config: Config = await getConfig(argv.configFile);
-  const { ethClient, ethProvider } = await initClients(config);
-
-  const db = new Database(config.database);
-  await db.init();
-
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase, ENTITY_TO_LATEST_ENTITY_MAP);
-  await graphDb.init();
-
-  const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);
-
-  const jobQueueConfig = config.jobQueue;
-  assert(jobQueueConfig, 'Missing job queue config');
-
-  const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
-  assert(dbConnectionString, 'Missing job queue db connection string');
-
-  const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
-  await jobQueue.start();
-
-  const indexer = new Indexer(config.server, db, { ethClient }, ethProvider, jobQueue, graphWatcher);
-  await indexer.init();
-
-  graphWatcher.setIndexer(indexer);
-  await graphWatcher.init();
-
-  const state = await indexer.getStateByCID(argv.cid);
-  assert(state, 'State for the provided CID doesn\'t exist.');
-
-  const stateData = await indexer.getStateData(state);
-
-  log(util.inspect(stateData, false, null));
+  await inspectCIDCmd.exec();
 };
 
 main().catch(err => {

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -256,7 +256,7 @@ export class Indexer implements IndexerInterface {
 
   async processInitialState (contractAddress: string, blockHash: string): Promise<any> {
     // TODO: Call initial state hook.
-    return {};
+    return undefined;
   }
 
   async processCheckpoint (blockHash: string): Promise<void> {
@@ -265,7 +265,12 @@ export class Indexer implements IndexerInterface {
 
   async processCLICheckpoint (contractAddress: string, blockHash?: string): Promise<string | undefined> {
     // TODO Implement
-    return '';
+    return undefined;
+  }
+
+  async getStateByCID (cid: string): Promise<State | undefined> {
+    // TODO Implement
+    return undefined;
   }
 
   getStateData (state: State): any {

--- a/packages/erc721-watcher/src/cli/inspect-cid.ts
+++ b/packages/erc721-watcher/src/cli/inspect-cid.ts
@@ -2,13 +2,10 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import assert from 'assert';
-import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
-import util from 'util';
 
-import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue } from '@cerc-io/util';
+import { InspectCIDCmd } from '@cerc-io/cli';
 
 import { Database } from '../database';
 import { Indexer } from '../indexer';
@@ -16,49 +13,10 @@ import { Indexer } from '../indexer';
 const log = debug('vulcanize:inspect-cid');
 
 const main = async (): Promise<void> => {
-  const argv = await yargs.parserConfiguration({
-    'parse-numbers': false
-  }).options({
-    configFile: {
-      alias: 'f',
-      type: 'string',
-      require: true,
-      demandOption: true,
-      describe: 'Configuration file path (toml)',
-      default: DEFAULT_CONFIG_PATH
-    },
-    cid: {
-      alias: 'c',
-      type: 'string',
-      demandOption: true,
-      describe: 'CID to be inspected'
-    }
-  }).argv;
+  const inspectCIDCmd = new InspectCIDCmd();
+  await inspectCIDCmd.init(Database, Indexer);
 
-  const config: Config = await getConfig(argv.configFile);
-  const { ethClient, ethProvider } = await initClients(config);
-
-  const db = new Database(config.database);
-  await db.init();
-
-  const jobQueueConfig = config.jobQueue;
-  assert(jobQueueConfig, 'Missing job queue config');
-
-  const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
-  assert(dbConnectionString, 'Missing job queue db connection string');
-
-  const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
-  await jobQueue.start();
-
-  const indexer = new Indexer(config.server, db, { ethClient }, ethProvider, jobQueue);
-  await indexer.init();
-
-  const state = await indexer.getStateByCID(argv.cid);
-  assert(state, 'State for the provided CID doesn\'t exist.');
-
-  const stateData = await indexer.getStateData(state);
-
-  log(util.inspect(stateData, false, null));
+  await inspectCIDCmd.exec();
 };
 
 main().catch(err => {

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -204,6 +204,10 @@ export class Indexer implements IndexerInterface {
     return undefined;
   }
 
+  async getStateByCID (cid: string): Promise<StateInterface | undefined> {
+    return undefined;
+  }
+
   getStateData (state: StateInterface): any {
     return undefined;
   }

--- a/packages/graph-test-watcher/src/cli/inspect-cid.ts
+++ b/packages/graph-test-watcher/src/cli/inspect-cid.ts
@@ -2,14 +2,10 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import assert from 'assert';
-import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
-import util from 'util';
 
-import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue } from '@cerc-io/util';
-import { GraphWatcher, Database as GraphDatabase } from '@cerc-io/graph-node';
+import { InspectCIDCmd } from '@cerc-io/cli';
 
 import { Database } from '../database';
 import { Indexer } from '../indexer';
@@ -17,57 +13,10 @@ import { Indexer } from '../indexer';
 const log = debug('vulcanize:inspect-cid');
 
 const main = async (): Promise<void> => {
-  const argv = await yargs.parserConfiguration({
-    'parse-numbers': false
-  }).options({
-    configFile: {
-      alias: 'f',
-      type: 'string',
-      require: true,
-      demandOption: true,
-      describe: 'Configuration file path (toml)',
-      default: DEFAULT_CONFIG_PATH
-    },
-    cid: {
-      alias: 'c',
-      type: 'string',
-      demandOption: true,
-      describe: 'CID to be inspected'
-    }
-  }).argv;
+  const inspectCIDCmd = new InspectCIDCmd();
+  await inspectCIDCmd.init(Database, Indexer);
 
-  const config: Config = await getConfig(argv.configFile);
-  const { ethClient, ethProvider } = await initClients(config);
-
-  const db = new Database(config.database);
-  await db.init();
-
-  const graphDb = new GraphDatabase(config.server, db.baseDatabase);
-  await graphDb.init();
-
-  const graphWatcher = new GraphWatcher(graphDb, ethClient, ethProvider, config.server);
-
-  const jobQueueConfig = config.jobQueue;
-  assert(jobQueueConfig, 'Missing job queue config');
-
-  const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
-  assert(dbConnectionString, 'Missing job queue db connection string');
-
-  const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
-  await jobQueue.start();
-
-  const indexer = new Indexer(config.server, db, { ethClient }, ethProvider, jobQueue, graphWatcher);
-  await indexer.init();
-
-  graphWatcher.setIndexer(indexer);
-  await graphWatcher.init();
-
-  const state = await indexer.getStateByCID(argv.cid);
-  assert(state, 'State for the provided CID doesn\'t exist.');
-
-  const stateData = await indexer.getStateData(state);
-
-  log(util.inspect(stateData, false, null));
+  await inspectCIDCmd.exec();
 };
 
 main().catch(err => {

--- a/packages/mobymask-watcher/src/cli/inspect-cid.ts
+++ b/packages/mobymask-watcher/src/cli/inspect-cid.ts
@@ -2,13 +2,10 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import assert from 'assert';
-import yargs from 'yargs';
 import 'reflect-metadata';
 import debug from 'debug';
-import util from 'util';
 
-import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients, JobQueue } from '@cerc-io/util';
+import { InspectCIDCmd } from '@cerc-io/cli';
 
 import { Database } from '../database';
 import { Indexer } from '../indexer';
@@ -16,49 +13,10 @@ import { Indexer } from '../indexer';
 const log = debug('vulcanize:inspect-cid');
 
 const main = async (): Promise<void> => {
-  const argv = await yargs.parserConfiguration({
-    'parse-numbers': false
-  }).options({
-    configFile: {
-      alias: 'f',
-      type: 'string',
-      require: true,
-      demandOption: true,
-      describe: 'Configuration file path (toml)',
-      default: DEFAULT_CONFIG_PATH
-    },
-    cid: {
-      alias: 'c',
-      type: 'string',
-      demandOption: true,
-      describe: 'CID to be inspected'
-    }
-  }).argv;
+  const inspectCIDCmd = new InspectCIDCmd();
+  await inspectCIDCmd.init(Database, Indexer);
 
-  const config: Config = await getConfig(argv.configFile);
-  const { ethClient, ethProvider } = await initClients(config);
-
-  const db = new Database(config.database);
-  await db.init();
-
-  const jobQueueConfig = config.jobQueue;
-  assert(jobQueueConfig, 'Missing job queue config');
-
-  const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
-  assert(dbConnectionString, 'Missing job queue db connection string');
-
-  const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
-  await jobQueue.start();
-
-  const indexer = new Indexer(config.server, db, { ethClient }, ethProvider, jobQueue);
-  await indexer.init();
-
-  const state = await indexer.getStateByCID(argv.cid);
-  assert(state, 'State for the provided CID doesn\'t exist.');
-
-  const stateData = await indexer.getStateData(state);
-
-  log(util.inspect(stateData, false, null));
+  await inspectCIDCmd.exec();
 };
 
 main().catch(err => {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -124,6 +124,7 @@ export interface IndexerInterface {
   updateSubgraphState?: (contractAddress: string, data: any) => void
   updateStateStatusMap (address: string, stateStatus: StateStatus): void
   getStateData (state: StateInterface): any
+  getStateByCID (cid: string): Promise<StateInterface | undefined>
   resetWatcherToBlock (blockNumber: number): Promise<void>
   getResultEvent (event: EventInterface): any
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/185

- Move inspect-cid CLI to `cli` package