### PR TITLE
Reduce disconnect frequency between peers

### DIFF
--- a/packages/peer/src/constants.ts
+++ b/packages/peer/src/constants.ts
@@ -2,4 +2,5 @@
 // Copyright 2023 Vulcanize, Inc.
 //
 
-export const PUBSUB_DISCOVERY_INTERVAL = 1000; // ms
+export const PUBSUB_DISCOVERY_INTERVAL = 1000; // 1 second
+export const HOP_TIMEOUT = 24 * 60 * 60 * 1000; // 1 day

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -98,7 +98,7 @@ export class Peer {
         }
       },
       connectionManager: {
-        maxDialsPerPeer: 1 // Number of max concurrent dials per peer
+        maxDialsPerPeer: 3 // Number of max concurrent dials per peer
       }
     });
 

--- a/packages/peer/src/relay.ts
+++ b/packages/peer/src/relay.ts
@@ -14,7 +14,7 @@ import { floodsub } from '@libp2p/floodsub';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 
 import { DEFAULT_SIGNAL_SERVER_URL } from './index.js';
-import { PUBSUB_DISCOVERY_INTERVAL } from './constants.js';
+import { HOP_TIMEOUT, PUBSUB_DISCOVERY_INTERVAL } from './constants.js';
 
 interface Arguments {
   signalServer: string;
@@ -47,7 +47,8 @@ async function main (): Promise<void> {
     relay: {
       enabled: true,
       hop: {
-        enabled: true
+        enabled: true,
+        timeout: HOP_TIMEOUT
       },
       advertise: {
         enabled: true


### PR DESCRIPTION
- Restrict the number of max concurrent dials per peer
- Increase hop timeout for the relay node to reduce disconnect frequency between peers