### PR TITLE
Use `StrictSign` signature policy in pubsub

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,7 +31,7 @@ A basic CLI to pass messages between peers using `stdin`/`stdout`
   yarn create-peer --file [PEER_ID_FILE_PATH]
   ```
 
-  * `file (f)`: file path to export the peer id to (json)
+  * `file (f)`: file path to export the peer id to (json) (default: logs to console)
 
 * (Optional) Run a local relay node:
 

--- a/packages/peer-test-app/README.md
+++ b/packages/peer-test-app/README.md
@@ -33,7 +33,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
   yarn create-peer --file [PEER_ID_FILE_PATH]
   ```
 
-  * `file (f)`: file path to export the peer id to (json)
+  * `file (f)`: file path to export the peer id to (json) (default: logs to console)
 
 * (Optional) Run a local relay node:
 

--- a/packages/peer-test-app/src/App.tsx
+++ b/packages/peer-test-app/src/App.tsx
@@ -38,8 +38,8 @@ function App() {
       peer.broadcastMessage(message)
     }
 
-    const unsubscribeTopic = peer.subscribeTopic(TEST_TOPIC, (data) => {
-      console.log(`> ${data}`)
+    const unsubscribeTopic = peer.subscribeTopic(TEST_TOPIC, (peerId, data) => {
+      console.log(`${peerId.toString()} > ${data}`)
     })
 
     window.flood = (message: string) => {

--- a/packages/peer/src/constants.ts
+++ b/packages/peer/src/constants.ts
@@ -3,4 +3,6 @@
 //
 
 export const PUBSUB_DISCOVERY_INTERVAL = 10000; // 10 seconds
+export const PUBSUB_SIGNATURE_POLICY = 'StrictSign';
+
 export const HOP_TIMEOUT = 24 * 60 * 60 * 1000; // 1 day

--- a/packages/peer/src/create-peer.ts
+++ b/packages/peer/src/create-peer.ts
@@ -15,11 +15,6 @@ interface Arguments {
 }
 
 async function main (): Promise<void> {
-  const argv: Arguments = _getArgv();
-
-  const exportFilePath = path.resolve(argv.file);
-  const exportFileDir = path.dirname(exportFilePath);
-
   const peerId = await createEd25519PeerId();
   assert(peerId.privateKey);
 
@@ -29,12 +24,20 @@ async function main (): Promise<void> {
     pubKey: Buffer.from(peerId.publicKey).toString('base64')
   };
 
-  if (!fs.existsSync(exportFileDir)) {
-    fs.mkdirSync(exportFileDir, { recursive: true });
-  }
+  const argv: Arguments = _getArgv();
+  if (argv.file) {
+    const exportFilePath = path.resolve(argv.file);
+    const exportFileDir = path.dirname(exportFilePath);
 
-  fs.writeFileSync(exportFilePath, JSON.stringify(obj));
-  console.log(`Peer id ${peerId.toString()} exported to file ${exportFilePath}`);
+    if (!fs.existsSync(exportFileDir)) {
+      fs.mkdirSync(exportFileDir, { recursive: true });
+    }
+
+    fs.writeFileSync(exportFilePath, JSON.stringify(obj, null, 2));
+    console.log(`Peer id ${peerId.toString()} exported to file ${exportFilePath}`);
+  } else {
+    console.log(obj);
+  }
 }
 
 function _getArgv (): any {
@@ -44,8 +47,7 @@ function _getArgv (): any {
     file: {
       type: 'string',
       alias: 'f',
-      describe: 'Peer Id export file path (json)',
-      demandOption: true
+      describe: 'Peer Id export file path (json)'
     }
   }).argv;
 }

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -234,6 +234,7 @@ export class Peer {
 
     // Log connected peer
     console.log(`Connected to ${remotePeerId.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
+    console.log(`Current number of peers connected: ${this._node?.getPeers().length}`);
   }
 
   _handleDisconnect (connection: Connection): void {
@@ -242,6 +243,7 @@ export class Peer {
 
     // Log disconnected peer
     console.log(`Disconnected from ${disconnectedPeerId.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
+    console.log(`Current number of peers connected: ${this._node?.getPeers().length}`);
   }
 
   async _connectPeer (peer: PeerInfo): Promise<void> {

--- a/packages/peer/src/relay.ts
+++ b/packages/peer/src/relay.ts
@@ -17,7 +17,7 @@ import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 import { createFromJSON } from '@libp2p/peer-id-factory';
 
 import { DEFAULT_SIGNAL_SERVER_URL } from './index.js';
-import { HOP_TIMEOUT, PUBSUB_DISCOVERY_INTERVAL } from './constants.js';
+import { HOP_TIMEOUT, PUBSUB_DISCOVERY_INTERVAL, PUBSUB_SIGNATURE_POLICY } from './constants.js';
 
 interface Arguments {
   signalServer: string;
@@ -55,7 +55,7 @@ async function main (): Promise<void> {
     ],
     connectionEncryption: [noise()],
     streamMuxers: [mplex()],
-    pubsub: floodsub(),
+    pubsub: floodsub({ globalSignaturePolicy: PUBSUB_SIGNATURE_POLICY }),
     peerDiscovery: [
       pubsubPeerDiscovery({
         interval: PUBSUB_DISCOVERY_INTERVAL


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Use `StrictSign` signature policy in pubsub to get source peer id on the receiver side
- Log number of currently connected peers on connect / disconnect events
- Log generated peer id to console if file path not provided in peer id generation