### PR TITLE
Federated relay nodes and limiting connections 

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,11 +37,12 @@ A basic CLI to pass messages between peers using `stdin`/`stdout`
 
   ```bash
   # In packages/peer
-  yarn relay-node --signal-server [SIGNAL_SERVER_URL] --peer-id-file [PEER_ID_FILE_PATH]
+  yarn relay-node --signal-server [SIGNAL_SERVER_URL] --peer-id-file [PEER_ID_FILE_PATH] --relay-peers [RELAY_PEERS_FILE_PATH]
   ```
 
   * `signal-server`: multiaddr of a signalling server (default: local signalling server multiaddr)
   * `peer-id-file`: file path for peer id to be used (json)
+  * `relay-peers`: file path for relay peer multiaddr(s) to dial to (json)
 
 * Start the node:
 
@@ -51,6 +52,6 @@ A basic CLI to pass messages between peers using `stdin`/`stdout`
   ```
 
   * `signal-server`: multiaddr of a signalling server (default: local signalling server multiaddr)
-  * `relay-node`: multiaddr of a hop enabled relay node
+  * `relay-node`: multiaddr of a primary hop enabled relay node
 
 * The process starts reading from `stdin` and outputs messages from others peers to `stdout`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,7 +42,7 @@ A basic CLI to pass messages between peers using `stdin`/`stdout`
 
   * `signal-server`: multiaddr of a signalling server (default: local signalling server multiaddr)
   * `peer-id-file`: file path for peer id to be used (json)
-  * `relay-peers`: file path for relay peer multiaddr(s) to dial to (json)
+  * `relay-peers`: file path for relay peer multiaddr(s) to dial on startup (json)
 
 * Start the node:
 

--- a/packages/peer-test-app/README.md
+++ b/packages/peer-test-app/README.md
@@ -44,7 +44,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
   * `signal-server`: multiaddr of a signalling server (default: local signalling server multiaddr)
   * `peer-id-file`: file path for peer id to be used (json)
-  * `relay-peers`: file path for relay peer multiaddr(s) to dial to (json)
+  * `relay-peers`: file path for relay peer multiaddr(s) to dial on startup (json)
 
 * Set the signalling server and primary relay node multiaddrs in the [env](./.env) file:
 

--- a/packages/peer-test-app/README.md
+++ b/packages/peer-test-app/README.md
@@ -39,13 +39,14 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
   ```bash
   # In packages/peer
-  yarn relay-node --signal-server [SIGNAL_SERVER_URL] --peer-id-file [PEER_ID_FILE_PATH]
+  yarn relay-node --signal-server [SIGNAL_SERVER_URL] --peer-id-file [PEER_ID_FILE_PATH] --relay-peers [RELAY_PEERS_FILE_PATH]
   ```
 
   * `signal-server`: multiaddr of a signalling server (default: local signalling server multiaddr)
   * `peer-id-file`: file path for peer id to be used (json)
+  * `relay-peers`: file path for relay peer multiaddr(s) to dial to (json)
 
-* Set the signalling server and relay node multiaddrs in the [env](./.env) file:
+* Set the signalling server and primary relay node multiaddrs in the [env](./.env) file:
 
   ```
   REACT_APP_SIGNAL_SERVER=/ip4/127.0.0.1/tcp/13579/ws/p2p-webrtc-star/

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -35,6 +35,7 @@
     "@libp2p/pubsub-peer-discovery": "^7.0.1",
     "@libp2p/webrtc-star": "^5.0.3",
     "@multiformats/multiaddr": "^11.1.4",
+    "debug": "^4.3.1",
     "it-length-prefixed": "^8.0.4",
     "it-map": "^2.0.0",
     "it-pipe": "^2.0.5",

--- a/packages/peer/src/constants.ts
+++ b/packages/peer/src/constants.ts
@@ -11,3 +11,8 @@ export const RELAY_TAG = {
   tag: 'laconic:relay-primary',
   value: 100
 };
+
+// Peer connection manager config constants
+export const MAX_DIALS_PER_PEER = 3;
+export const MAX_CONNECTIONS = 10;
+export const MIN_CONNECTIONS = 0;

--- a/packages/peer/src/constants.ts
+++ b/packages/peer/src/constants.ts
@@ -6,3 +6,8 @@ export const PUBSUB_DISCOVERY_INTERVAL = 10000; // 10 seconds
 export const PUBSUB_SIGNATURE_POLICY = 'StrictSign';
 
 export const HOP_TIMEOUT = 24 * 60 * 60 * 1000; // 1 day
+
+export const RELAY_TAG = {
+  tag: 'laconic:relay-primary',
+  value: 100
+};

--- a/packages/peer/src/constants.ts
+++ b/packages/peer/src/constants.ts
@@ -2,17 +2,32 @@
 // Copyright 2023 Vulcanize, Inc.
 //
 
+// How often a peer should broadcast it's peer data over pubsub discovery topic
+// (interval at which other peers get corresponding discovery event)
 export const PUBSUB_DISCOVERY_INTERVAL = 10000; // 10 seconds
+
+// Use StrictSign signature policy to pass signed pubsub messages
+// (includes source peer's id with a signature in the message)
 export const PUBSUB_SIGNATURE_POLICY = 'StrictSign';
 
+// Relayed connections between peers drop after hop timeout
+// (redialled on discovery)
 export const HOP_TIMEOUT = 24 * 60 * 60 * 1000; // 1 day
 
+// Connected peers can be given tags according to their priority
+// Create a high value tag for prioritizing primary relay node connection
 export const RELAY_TAG = {
   tag: 'laconic:relay-primary',
   value: 100
 };
 
 // Peer connection manager config constants
-export const MAX_DIALS_PER_PEER = 3;
+
+// Number of max concurrent dials per peer
+export const MAX_CONCURRENT_DIALS_PER_PEER = 3;
+
+// Max number of connections for a peer after which it starts pruning connections
 export const MAX_CONNECTIONS = 10;
+
+// Min number of connections for a peer below which autodial triggers (if enabled)
 export const MIN_CONNECTIONS = 0;

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -24,7 +24,7 @@ import { multiaddr, Multiaddr } from '@multiformats/multiaddr';
 import { floodsub } from '@libp2p/floodsub';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 
-import { PUBSUB_DISCOVERY_INTERVAL, PUBSUB_SIGNATURE_POLICY } from './constants.js';
+import { PUBSUB_DISCOVERY_INTERVAL, PUBSUB_SIGNATURE_POLICY, RELAY_TAG } from './constants.js';
 
 export const CHAT_PROTOCOL = '/chat/1.0.0';
 export const DEFAULT_SIGNAL_SERVER_URL = '/ip4/127.0.0.1/tcp/13579/wss/p2p-webrtc-star';
@@ -114,6 +114,13 @@ export class Peer {
 
       console.log(`Dialling relay node ${relayMultiaddr.getPeerId()} using multiaddr ${relayMultiaddr.toString()}`);
       await this._node.dial(relayMultiaddr);
+
+      // Tag the relay node with a high value to avoid disconnect on crossing maxConnections limit
+      const relayPeerId = this._node.getPeers().find(
+        peerId => peerId.toString() === relayMultiaddr.getPeerId()
+      );
+      assert(relayPeerId);
+      this._node.peerStore.tagPeer(relayPeerId, RELAY_TAG.tag, { value: RELAY_TAG.value });
     }
 
     // Listen for change in stored multiaddrs

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -263,6 +263,11 @@ export class Peer {
     // Dial them when we discover them
     // Attempt to dial all the multiaddrs of the discovered peer (to connect through relay)
     for (const peerMultiaddr of peer.multiaddrs) {
+      // Avoid incomplete multiaddr
+      if (!peerMultiaddr.toString().includes('p2p/')) {
+        continue;
+      }
+
       try {
         console.log(`Dialling peer ${peer.id.toString()} using multiaddr ${peerMultiaddr.toString()}`);
         const stream = await this._node.dialProtocol(peerMultiaddr, CHAT_PROTOCOL);

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -24,7 +24,7 @@ import { multiaddr, Multiaddr } from '@multiformats/multiaddr';
 import { floodsub } from '@libp2p/floodsub';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 
-import { PUBSUB_DISCOVERY_INTERVAL, PUBSUB_SIGNATURE_POLICY, RELAY_TAG } from './constants.js';
+import { MAX_CONNECTIONS, MAX_DIALS_PER_PEER, MIN_CONNECTIONS, PUBSUB_DISCOVERY_INTERVAL, PUBSUB_SIGNATURE_POLICY, RELAY_TAG } from './constants.js';
 
 export const CHAT_PROTOCOL = '/chat/1.0.0';
 export const DEFAULT_SIGNAL_SERVER_URL = '/ip4/127.0.0.1/tcp/13579/wss/p2p-webrtc-star';
@@ -99,10 +99,10 @@ export class Peer {
         }
       },
       connectionManager: {
-        maxDialsPerPeer: 3, // Number of max concurrent dials per peer
+        maxDialsPerPeer: MAX_DIALS_PER_PEER, // Number of max concurrent dials per peer
         autoDial: false,
-        maxConnections: 5,
-        minConnections: 0
+        maxConnections: MAX_CONNECTIONS,
+        minConnections: MIN_CONNECTIONS
       }
     });
 

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -100,7 +100,9 @@ export class Peer {
       },
       connectionManager: {
         maxDialsPerPeer: 3, // Number of max concurrent dials per peer
-        autoDial: false
+        autoDial: false,
+        maxConnections: 5,
+        minConnections: 0
       }
     });
 

--- a/packages/peer/src/relay.ts
+++ b/packages/peer/src/relay.ts
@@ -8,6 +8,7 @@ import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs';
 import fs from 'fs';
 import path from 'path';
+import debug from 'debug';
 
 import { noise } from '@chainsafe/libp2p-noise';
 import { mplex } from '@libp2p/mplex';
@@ -20,6 +21,8 @@ import type { Connection } from '@libp2p/interface-connection';
 import { DEFAULT_SIGNAL_SERVER_URL } from './index.js';
 import { HOP_TIMEOUT, PUBSUB_DISCOVERY_INTERVAL, PUBSUB_SIGNATURE_POLICY } from './constants.js';
 import { multiaddr } from '@multiformats/multiaddr';
+
+const log = debug('vulcanize:relay');
 
 interface Arguments {
   signalServer: string;
@@ -89,7 +92,7 @@ async function main (): Promise<void> {
     // console.log('event peer:connect', evt);
     // Log connected peer
     const connection: Connection = evt.detail;
-    console.log(`Connected to ${connection.remotePeer.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
+    log(`Connected to ${connection.remotePeer.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
   });
 
   // Listen for peers disconnecting
@@ -97,7 +100,7 @@ async function main (): Promise<void> {
     // console.log('event peer:disconnect', evt);
     // Log disconnected peer
     const connection: Connection = evt.detail;
-    console.log(`Disconnected from ${connection.remotePeer.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
+    log(`Disconnected from ${connection.remotePeer.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
   });
 
   if (argv.relayPeers) {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Network configurations with more than one relay server
  - Add an option to pass relay node a list of relay peers to connect on startup
- Restrict max number of connections for a peer