### PR TITLE
Fix for multiple connections between two peers

### DIFF
--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -263,17 +263,25 @@ export class Peer {
   }
 
   async _handleConnect (connection: Connection): Promise<void> {
+    assert(this._node);
     const remotePeerId = connection.remotePeer;
+    const remoteConnections = this._node.getConnections(remotePeerId);
 
-    if (this._node?.getPeers().some(peerId => peerId.toString() === remotePeerId.toString())) {
-      console.log('closing connection');
-      await connection.close();
+    if (remoteConnections.length > 1) {
+      console.log('closing connections');
+
+      for (const remoteConnection of remoteConnections) {
+        if (remoteConnection.id !== connection.id) {
+          await remoteConnection.close();
+        }
+      }
+
       console.log('closed');
     }
 
     // Log connected peer
     console.log(`Connected to ${remotePeerId.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
-    console.log(`Current number of peers connected: ${this._node?.getPeers().length}`);
+    console.log(`Current number of peers connected: ${this._node.getPeers().length}`);
 
     // Start heartbeat check peer
     await this._startHeartbeatChecks(

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -267,20 +267,22 @@ export class Peer {
     const remotePeerId = connection.remotePeer;
     const remoteConnections = this._node.getConnections(remotePeerId);
 
-    if (remoteConnections.length > 1) {
-      console.log('closing connections');
-
-      for (const remoteConnection of remoteConnections) {
-        if (remoteConnection.id !== connection.id) {
-          await remoteConnection.close();
-        }
-      }
-
-      console.log('closed');
-    }
-
     // Log connected peer
     console.log(`Connected to ${remotePeerId.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
+
+    if (remoteConnections.length > 1) {
+      // Close connections only on one of the peers.
+      // Connections are closed on peer with the smaller id.
+      if (this._node.peerId.toString() < remotePeerId.toString()) {
+        console.log('Closing new connection for already connected peer');
+        // Close new connection as protocol stream is opened in the first connection that is established.
+        await connection.close();
+        console.log('Closed');
+      }
+
+      return;
+    }
+
     console.log(`Current number of peers connected: ${this._node.getPeers().length}`);
 
     // Start heartbeat check peer

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -270,9 +270,9 @@ export class Peer {
     // Log connected peer
     console.log(`Connected to ${remotePeerId.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
 
+    // Keep only one connection with a peer.
     if (remoteConnections.length > 1) {
-      // Close connections only on one of the peers.
-      // Connections are closed on peer with the smaller id.
+      // Close new connection from peer having the smaller peer id.
       if (this._node.peerId.toString() < remotePeerId.toString()) {
         console.log('Closing new connection for already connected peer');
         // Close new connection as protocol stream is opened in the first connection that is established.

--- a/packages/peer/src/index.ts
+++ b/packages/peer/src/index.ts
@@ -265,6 +265,12 @@ export class Peer {
   async _handleConnect (connection: Connection): Promise<void> {
     const remotePeerId = connection.remotePeer;
 
+    if (this._node?.getPeers().some(peerId => peerId.toString() === remotePeerId.toString())) {
+      console.log('closing connection');
+      await connection.close();
+      console.log('closed');
+    }
+
     // Log connected peer
     console.log(`Connected to ${remotePeerId.toString()} using multiaddr ${connection.remoteAddr.toString()}`);
     console.log(`Current number of peers connected: ${this._node?.getPeers().length}`);


### PR DESCRIPTION
Part of #289 

- Close new connections for already connected peers
- Refresh react components in intervals to update peer connections list in UI