### PR TITLE
Fix getting bytes value length from storage slot in solidity mapper

### DIFF
--- a/packages/solidity-mapper/test/contracts/TestBytes.sol
+++ b/packages/solidity-mapper/test/contracts/TestBytes.sol
@@ -13,8 +13,7 @@ contract TestBytes {
     // If data is 32 or more bytes, the main slot stores the value length * 2 + 1 and the data is stored in keccak256(slot).
     // Else the main slot stores the data and value length * 2.
     // https://docs.soliditylang.org/en/v0.7.4/internals/layout_in_storage.html#bytes-and-string
-    bytes bytesArray1;
-    bytes bytesArray2;
+    bytes byteArray;
 
     // Set variable bytesTen.
     function setBytesTen(bytes10 value) external {
@@ -31,13 +30,8 @@ contract TestBytes {
         bytesThirty = value;
     }
 
-    // Set variable bytesArray1.
-    function setBytesArray1(bytes calldata value) external {
-        bytesArray1 = value;
-    }
-
-    // Set variable bytesArray2.
-    function setBytesArray2(bytes calldata value) external {
-        bytesArray2 = value;
+    // Set variable byteArray.
+    function setByteArray(bytes calldata value) external {
+        byteArray = value;
     }
 }


### PR DESCRIPTION
Closes https://github.com/cerc-io/watcher-ts/issues/167

- Added test for bytes with leading zeros and length less than 32
- Issue was due to incorrect method of getting length of bytes value
- Fixed by checking lowest bit of storage slot for getting length according to [documentation](https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_storage.html#bytes-and-string) 