### PR TITLE
Maintain connection between relay nodes in federated relay network

### DIFF
--- a/packages/peer/src/utils/index.ts
+++ b/packages/peer/src/utils/index.ts
@@ -5,15 +5,31 @@
 import { Libp2p } from '@cerc-io/libp2p';
 import { Multiaddr } from '@multiformats/multiaddr';
 
+interface DialWithRetryOptions {
+  redialDelay: number
+  maxRetry: number
+}
+
+const DEFAULT_DIAL_RETRY_OPTIONS: DialWithRetryOptions = {
+  redialDelay: 5000, // ms
+  maxRetry: 5
+};
+
 /**
  * Method to dial remote peer multiaddr with retry on failure
+ * Number of retries can be configured using options.maxRetry
  * @param node
  * @param multiaddr
- * @param redialDelay
+ * @param options
  */
-export const dialWithRetry = async (node: Libp2p, multiaddr: Multiaddr, redialDelay: number) => {
+export const dialWithRetry = async (node: Libp2p, multiaddr: Multiaddr, options: Partial<DialWithRetryOptions>) => {
+  const { redialDelay, maxRetry } = {
+    ...DEFAULT_DIAL_RETRY_OPTIONS,
+    ...options
+  };
+
   // Keep dialling node until it connects
-  while (true) {
+  for (let i = 0; i < maxRetry; i++) {
     try {
       console.log(`Dialling node ${multiaddr.getPeerId()} using multiaddr ${multiaddr.toString()}`);
       const connection = await node.dial(multiaddr);
@@ -28,4 +44,6 @@ export const dialWithRetry = async (node: Libp2p, multiaddr: Multiaddr, redialDe
       await new Promise(resolve => setTimeout(resolve, redialDelay));
     }
   }
+
+  throw new Error(`Stopping dial retry after ${maxRetry} attempts for multiaddr ${multiaddr.toString()}`);
 };


### PR DESCRIPTION
Part of #289

- Redial to relay peers on disconnect
- Added option `maxDialRetry` for configuring number of dial attempts to relay peers 