### PR TITLE
Send mobymask p2p messages to laconicd

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,3 +15,4 @@ export * from './job-runner';
 export * from './index-block';
 export * from './fill';
 export * from './peer';
+export * from './utils';

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -158,7 +158,7 @@ export class Indexer implements IndexerInterface {
     if (this._serverMode === ETH_CALL_MODE) {
       const contract = new ethers.Contract(token, this._abi, this._ethProvider);
 
-      // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
+      // eth_call doesn't support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
       const value = await contract.balanceOf(owner, { blockTag: blockHash });
 
       result = {

--- a/packages/mobymask-v2-watcher/package.json
+++ b/packages/mobymask-v2-watcher/package.json
@@ -25,7 +25,7 @@
     "inspect-cid": "DEBUG=vulcanize:* ts-node src/cli/inspect-cid.ts",
     "index-block": "DEBUG=vulcanize:* ts-node src/cli/index-block.ts",
     "peer": "DEBUG='vulcanize:*, laconic:*' node --enable-source-maps dist/cli/peer.js",
-    "peer-laconic": "DEBUG='vulcanize:*, laconic:*' node --enable-source-maps dist/peer-laconic.js"
+    "peer-listener": "DEBUG='vulcanize:*, laconic:*' node --enable-source-maps dist/peer-listener.js"
   },
   "repository": {
     "type": "git",

--- a/packages/mobymask-v2-watcher/package.json
+++ b/packages/mobymask-v2-watcher/package.json
@@ -24,7 +24,8 @@
     "import-state:dev": "DEBUG=vulcanize:* ts-node src/cli/import-state.ts",
     "inspect-cid": "DEBUG=vulcanize:* ts-node src/cli/inspect-cid.ts",
     "index-block": "DEBUG=vulcanize:* ts-node src/cli/index-block.ts",
-    "peer": "DEBUG='vulcanize:*, laconic:*' node --enable-source-maps dist/cli/peer.js"
+    "peer": "DEBUG='vulcanize:*, laconic:*' node --enable-source-maps dist/cli/peer.js",
+    "peer-laconic": "DEBUG='vulcanize:*, laconic:*' node --enable-source-maps dist/peer-laconic.js"
   },
   "repository": {
     "type": "git",
@@ -42,6 +43,7 @@
     "@cerc-io/ipld-eth-client": "^0.2.30",
     "@cerc-io/solidity-mapper": "^0.2.30",
     "@cerc-io/util": "^0.2.30",
+    "@cerc-io/peer": "^0.2.30",
     "@ethersproject/providers": "^5.4.4",
     "apollo-type-bigint": "^0.1.3",
     "debug": "^4.3.1",

--- a/packages/mobymask-v2-watcher/src/indexer.ts
+++ b/packages/mobymask-v2-watcher/src/indexer.ts
@@ -270,7 +270,7 @@ export class Indexer implements IndexerInterface {
     defaultValue: any
   ): Promise<Entity> {
     const [{ number }, syncStatus] = await Promise.all([
-      // Laconic chain doesn't support eth_getHeaderByHash
+      // Laconicd doesn't support eth_getHeaderByHash
       // this._ethProvider.send('eth_getHeaderByHash', [blockHash]),
       this._ethProvider.getBlock(blockHash),
       this.getSyncStatus()
@@ -334,7 +334,7 @@ export class Indexer implements IndexerInterface {
       return {
         value,
         proof: {
-          // Returning null value as proof, since ethers library getStorageAt method doesnt return proof.
+          // Returning null value as proof, since ethers library getStorageAt method doesn't return proof.
           data: JSON.stringify(null)
         }
       };

--- a/packages/mobymask-v2-watcher/src/libp2p-utils.ts
+++ b/packages/mobymask-v2-watcher/src/libp2p-utils.ts
@@ -47,11 +47,10 @@ export async function sendMessageToL2 (
 
       case MESSAGE_KINDS.REVOKE: {
         const { signedDelegation, signedIntendedRevocation } = message;
-        const parsedSignedIntendedRevocation = _parseSignedIntendedRevocation(signedIntendedRevocation);
 
         const transaction: TransactionResponse = await contract.revokeDelegation(
           signedDelegation,
-          parsedSignedIntendedRevocation,
+          signedIntendedRevocation,
           // Setting gasLimit as eth_estimateGas call takes too long in L2 chain
           { gasLimit }
         );
@@ -126,20 +125,5 @@ function _parseRevocation (log: debug.Debugger, msg: any): void {
   log('Signed delegation:');
   log(JSON.stringify(signedDelegation, null, 2));
   log('Signed intention to revoke:');
-  const stringifiedSignedIntendedRevocation = JSON.stringify(
-    _parseSignedIntendedRevocation(signedIntendedRevocation),
-    null,
-    2
-  );
-  log(stringifiedSignedIntendedRevocation);
-}
-
-function _parseSignedIntendedRevocation (signedIntendedRevocation: any): any {
-  // TODO: Parse broadcast messages with types not supported by JSON
-  return {
-    ...signedIntendedRevocation,
-    intentionToRevoke: {
-      delegationHash: ethers.utils.hexlify(Buffer.from(signedIntendedRevocation.intentionToRevoke.delegationHash))
-    }
-  };
+  log(JSON.stringify(signedIntendedRevocation, null, 2));
 }

--- a/packages/mobymask-v2-watcher/src/peer-laconic.ts
+++ b/packages/mobymask-v2-watcher/src/peer-laconic.ts
@@ -1,0 +1,90 @@
+import debug from 'debug';
+import { hideBin } from 'yargs/helpers';
+import yargs from 'yargs';
+import assert from 'assert';
+
+import { Config, DEFAULT_CONFIG_PATH, getConfig, initClients } from '@cerc-io/util';
+import {
+  PeerInitConfig,
+  PeerIdObj
+  // @ts-expect-error https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1319854183
+} from '@cerc-io/peer';
+
+import { sendMessageToLaconic } from './libp2p-utils';
+import { readPeerId } from '@cerc-io/cli';
+import { ethers } from 'ethers';
+
+const log = debug('vulcanize:peer-laconic');
+
+export const main = async (): Promise<any> => {
+  const argv = _getArgv();
+  const config: Config = await getConfig(argv.configFile);
+  const { ethProvider } = await initClients(config);
+
+  const p2pConfig = config.server.p2p;
+  const peerConfig = p2pConfig.peer;
+  assert(peerConfig, 'Peer config not set');
+
+  const { Peer } = await import('@cerc-io/peer');
+
+  let peerIdObj: PeerIdObj | undefined;
+  if (peerConfig.peerIdFile) {
+    peerIdObj = readPeerId(peerConfig.peerIdFile);
+  }
+
+  const peer = new Peer(peerConfig.relayMultiaddr, true);
+
+  const peerNodeInit: PeerInitConfig = {
+    pingInterval: peerConfig.pingInterval,
+    pingTimeout: peerConfig.pingTimeout,
+    maxRelayConnections: peerConfig.maxRelayConnections,
+    relayRedialInterval: peerConfig.relayRedialInterval,
+    maxConnections: peerConfig.maxConnections,
+    dialTimeout: peerConfig.dialTimeout,
+    enableDebugInfo: peerConfig.enableDebugInfo
+  };
+
+  await peer.init(peerNodeInit, peerIdObj);
+  const wallet = new ethers.Wallet(argv.privateKey, ethProvider);
+
+  peer.subscribeTopic(peerConfig.pubSubTopic, (peerId, data) => {
+    log('Received a message on mobymask P2P network from peer:', peerId);
+
+    // TODO: throttle message handler
+    sendMessageToLaconic(wallet, argv.contractAddress, data);
+  });
+
+  log(`Peer ID: ${peer.peerId?.toString()}`);
+};
+
+const _getArgv = (): any => {
+  return yargs(hideBin(process.argv)).parserConfiguration({
+    'parse-numbers': false
+  }).options({
+    configFile: {
+      alias: 'config-file',
+      demandOption: true,
+      describe: 'configuration file path (toml)',
+      type: 'string',
+      default: DEFAULT_CONFIG_PATH
+    },
+    privateKey: {
+      alias: 'private-key',
+      demandOption: true,
+      describe: 'Private key of the laconic account used for eth_call',
+      type: 'string'
+    },
+    contractAddress: {
+      alias: 'contract',
+      demandOption: true,
+      describe: 'Address of MobyMask contract',
+      type: 'string'
+    }
+  }).argv;
+};
+
+main().then(() => {
+  log('Starting peer...');
+}).catch(err => {
+  log(err);
+});

--- a/packages/mobymask-v2-watcher/src/peer-listener.ts
+++ b/packages/mobymask-v2-watcher/src/peer-listener.ts
@@ -16,6 +16,15 @@ import { ethers } from 'ethers';
 
 const log = debug('vulcanize:peer-listener');
 
+const DEFAULT_GAS_LIMIT = 5000;
+
+interface Arguments {
+  configFile: string;
+  privateKey: string;
+  contractAddress: string;
+  gasLimit: number;
+}
+
 export const main = async (): Promise<any> => {
   const argv = _getArgv();
   const config: Config = await getConfig(argv.configFile);
@@ -51,19 +60,18 @@ export const main = async (): Promise<any> => {
     log('Received a message on mobymask P2P network from peer:', peerId);
 
     // TODO: throttle message handler
-    sendMessageToL2(wallet, argv.contractAddress, data);
+    sendMessageToL2(wallet, argv, data);
   });
 
   log(`Peer ID: ${peer.peerId?.toString()}`);
 };
 
-const _getArgv = (): any => {
+const _getArgv = (): Arguments => {
   return yargs(hideBin(process.argv)).parserConfiguration({
     'parse-numbers': false
   }).options({
     configFile: {
       alias: 'config-file',
-      demandOption: true,
       describe: 'configuration file path (toml)',
       type: 'string',
       default: DEFAULT_CONFIG_PATH
@@ -79,8 +87,15 @@ const _getArgv = (): any => {
       demandOption: true,
       describe: 'Address of MobyMask contract',
       type: 'string'
+    },
+    gasLimit: {
+      alias: 'gas-limit',
+      describe: 'Gas limit for eth txs',
+      type: 'number',
+      default: DEFAULT_GAS_LIMIT
     }
-  }).argv;
+  // https://github.com/yargs/yargs/blob/main/docs/typescript.md?plain=1#L83
+  }).parseSync();
 };
 
 main().then(() => {

--- a/packages/mobymask-v2-watcher/src/peer-listener.ts
+++ b/packages/mobymask-v2-watcher/src/peer-listener.ts
@@ -10,11 +10,11 @@ import {
   // @ts-expect-error https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1319854183
 } from '@cerc-io/peer';
 
-import { sendMessageToLaconic } from './libp2p-utils';
+import { sendMessageToL2 } from './libp2p-utils';
 import { readPeerId } from '@cerc-io/cli';
 import { ethers } from 'ethers';
 
-const log = debug('vulcanize:peer-laconic');
+const log = debug('vulcanize:peer-listener');
 
 export const main = async (): Promise<any> => {
   const argv = _getArgv();
@@ -51,7 +51,7 @@ export const main = async (): Promise<any> => {
     log('Received a message on mobymask P2P network from peer:', peerId);
 
     // TODO: throttle message handler
-    sendMessageToLaconic(wallet, argv.contractAddress, data);
+    sendMessageToL2(wallet, argv.contractAddress, data);
   });
 
   log(`Peer ID: ${peer.peerId?.toString()}`);
@@ -71,7 +71,7 @@ const _getArgv = (): any => {
     privateKey: {
       alias: 'private-key',
       demandOption: true,
-      describe: 'Private key of the laconic account used for eth_call',
+      describe: 'Private key of the account to use for eth_call',
       type: 'string'
     },
     contractAddress: {

--- a/packages/mobymask-v2-watcher/src/peer-listener.ts
+++ b/packages/mobymask-v2-watcher/src/peer-listener.ts
@@ -16,7 +16,7 @@ import { ethers } from 'ethers';
 
 const log = debug('vulcanize:peer-listener');
 
-const DEFAULT_GAS_LIMIT = 5000;
+const DEFAULT_GAS_LIMIT = 500000;
 
 interface Arguments {
   configFile: string;

--- a/packages/mobymask-v2-watcher/tsconfig.json
+++ b/packages/mobymask-v2-watcher/tsconfig.json
@@ -5,8 +5,8 @@
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2019"],                              /* Specify library files to be included in the compilation. */
+    "module": "CommonJS",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": [ "ES5", "ES6", "ES2020" ],              /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
@@ -44,7 +44,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "Node16",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/packages/solidity-mapper/test/utils.ts
+++ b/packages/solidity-mapper/test/utils.ts
@@ -13,7 +13,7 @@ import isArray from 'lodash/isArray';
 
 import { StorageLayout, GetStorageAt } from '../src';
 
-// storageLayout doesnt exist in type CompilerOutput doesnt.
+// storageLayout doesn't exist in type CompilerOutput doesn't.
 // Extending CompilerOutput type to include storageLayout property.
 interface StorageCompilerOutput extends CompilerOutput {
   contracts: {
@@ -82,7 +82,7 @@ export const getStorageAt: GetStorageAt = async ({ blockHash, contract, slot }) 
   return {
     value,
     proof: {
-      // Returning null value as proof, since ethers library getStorageAt method doesnt return proof.
+      // Returning null value as proof, since ethers library getStorageAt method doesn't return proof.
       // This function is used in tests to mock the getStorageAt method of ipld-eth-client which returns proof along with value.
       data: JSON.stringify(null)
     }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/321

- Add script to run peer with message handler for sending tx to laconicd
  - Send `invoke` contract method tx
  - Send `revokeDelegation` contract method tx
- Change GQL query handlers in v2-watcher to use laconicd ETH RPC endpoint instead of ipld-eth-server