### PR TITLE
Add flag in codegen to ignore errors for unhandled types

### DIFF
--- a/packages/codegen/src/artifacts.ts
+++ b/packages/codegen/src/artifacts.ts
@@ -4,13 +4,17 @@
 
 import solc from 'solc';
 
+interface Solc {
+  compile(input: string): any;
+}
+
 /**
  * Compiles the given contract using solc and returns resultant artifacts.
  * @param contractContent Contents of the contract file to be compiled.
  * @param contractFileName Input contract file name.
  * @param contractName Name of the main contract in the contract file.
  */
-export function generateArtifacts (contractContent: string, contractFileName: string, contractName: string): { abi: any[], storageLayout: any } {
+export async function generateArtifacts (contractContent: string, contractFileName: string, contractName: string, solcVersion: string): Promise<{ abi: any[], storageLayout: any }> {
   const input: any = {
     language: 'Solidity',
     sources: {},
@@ -27,6 +31,20 @@ export function generateArtifacts (contractContent: string, contractFileName: st
     content: contractContent
   };
 
+  const solcInstance = (solcVersion === undefined) ? solc : await getSolcByVersion(solcVersion);
+
   // Get artifacts for the required contract.
-  return JSON.parse(solc.compile(JSON.stringify(input))).contracts[contractFileName][contractName];
+  return JSON.parse(solcInstance.compile(JSON.stringify(input))).contracts[contractFileName][contractName];
+}
+
+async function getSolcByVersion (solcVersion: string): Promise<Solc> {
+  return new Promise((resolve, reject) => {
+    solc.loadRemoteVersion(solcVersion, (err: any, solcInstance: Solc | Promise<any>) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(solcInstance);
+      }
+    });
+  });
 }

--- a/packages/codegen/src/artifacts.ts
+++ b/packages/codegen/src/artifacts.ts
@@ -32,9 +32,20 @@ export async function generateArtifacts (contractContent: string, contractFileNa
   };
 
   const solcInstance = (solcVersion === undefined) ? solc : await getSolcByVersion(solcVersion);
+  const compiledContract = JSON.parse(solcInstance.compile(JSON.stringify(input)));
+
+  if (compiledContract.errors?.length) {
+    compiledContract.errors.forEach((error: any) => {
+      if (error.severity === 'error') {
+        throw new Error(error.formattedMessage);
+      }
+
+      console.log(`${error.severity}: ${error.formattedMessage}`);
+    });
+  }
 
   // Get artifacts for the required contract.
-  return JSON.parse(solcInstance.compile(JSON.stringify(input))).contracts[contractFileName][contractName];
+  return compiledContract.contracts[contractFileName][contractName];
 }
 
 async function getSolcByVersion (solcVersion: string): Promise<Solc> {

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -90,10 +90,11 @@ const main = async (): Promise<void> => {
       // Generate artifacts from contract.
       const inputFileName = path.basename(inputFile, '.sol');
 
-      const { abi, storageLayout } = generateArtifacts(
+      const { abi, storageLayout } = await generateArtifacts(
         contractData.contractString,
         `${inputFileName}.sol`,
-        contractData.contractName
+        contractData.contractName,
+        config.solc
       );
 
       contractData.contractAbi = abi;
@@ -387,6 +388,7 @@ function getConfig (configFile: string): any {
     mode: inputConfig.mode || MODE_ALL,
     kind: inputConfig.kind || KIND_ACTIVE,
     port: inputConfig.port || DEFAULT_PORT,
+    solc: inputConfig.solc,
     flatten,
     subgraphPath,
     subgraphConfig

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -48,7 +48,7 @@ const main = async (): Promise<void> => {
       type: 'string'
     })
     .option('continue-on-error', {
-      alias: 'C',
+      alias: 'e',
       demandOption: false,
       default: false,
       describe: 'Continue generating watcher if unhandled types encountered',

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -47,6 +47,13 @@ const main = async (): Promise<void> => {
       describe: 'Watcher generation config file path (yaml)',
       type: 'string'
     })
+    .option('continue-on-error', {
+      alias: 'C',
+      demandOption: false,
+      default: false,
+      describe: 'Continue generating watcher if unhandled types encountered',
+      type: 'boolean'
+    })
     .argv;
 
   const config = getConfig(path.resolve(argv['config-file']));
@@ -96,7 +103,8 @@ const main = async (): Promise<void> => {
     contracts.push(contractData);
   }
 
-  const visitor = new Visitor();
+  const continueOnError = argv['continue-on-error'];
+  const visitor = new Visitor(continueOnError);
 
   parseAndVisit(visitor, contracts, config.mode);
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/351

- Add `continue-on-error` flag in codegen CLI to ignore unhandled types and create watcher without them
- Use solc version defined in config
- Log unhandled types and compiler errors