### PR TITLE
Changes in codegen to remove lint warnings in generated watcher

### DIFF
--- a/packages/codegen/src/assets/.npmrc
+++ b/packages/codegen/src/assets/.npmrc
@@ -1,0 +1,1 @@
+@cerc-io:registry=https://git.vdb.to/api/packages/cerc-io/npm/

--- a/packages/codegen/src/assets/pre-commit
+++ b/packages/codegen/src/assets/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn lint

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -272,10 +272,17 @@ function generateWatcher (visitor: Visitor, contracts: any[], config: any, overW
     : process.stdout;
   writeFileToStream(path.join(ASSET_DIR, '.npmrc'), outStream);
 
+  const huskyPreCommitFilePath = path.join(outputDir, '.husky/pre-commit');
+
   outStream = outputDir
-    ? fs.createWriteStream(path.join(outputDir, '.husky/pre-commit'))
+    ? fs.createWriteStream(huskyPreCommitFilePath)
     : process.stdout;
   writeFileToStream(path.join(ASSET_DIR, 'pre-commit'), outStream);
+
+  if (fs.existsSync(huskyPreCommitFilePath)) {
+    // Set file permission to executable
+    fs.chmodSync(huskyPreCommitFilePath, '775');
+  }
 
   outStream = outputDir
     ? fs.createWriteStream(path.join(outputDir, 'src/job-runner.ts'))

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -264,6 +264,14 @@ function generateWatcher (visitor: Visitor, contracts: any[], config: any, overW
     : process.stdout;
   writeFileToStream(path.join(ASSET_DIR, '.gitignore'), outStream);
 
+  const huskyDir = path.join(outputDir, '.husky');
+  if (!fs.existsSync(huskyDir)) fs.mkdirSync(huskyDir);
+
+  outStream = outputDir
+    ? fs.createWriteStream(path.join(outputDir, '.husky/pre-commit'))
+    : process.stdout;
+  writeFileToStream(path.join(ASSET_DIR, 'pre-commit'), outStream);
+
   outStream = outputDir
     ? fs.createWriteStream(path.join(outputDir, 'src/job-runner.ts'))
     : process.stdout;

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -264,6 +264,11 @@ function generateWatcher (visitor: Visitor, contracts: any[], config: any, overW
     : process.stdout;
   writeFileToStream(path.join(ASSET_DIR, '.gitignore'), outStream);
 
+  outStream = outputDir
+    ? fs.createWriteStream(path.join(outputDir, '.npmrc'))
+    : process.stdout;
+  writeFileToStream(path.join(ASSET_DIR, '.npmrc'), outStream);
+
   const huskyDir = path.join(outputDir, '.husky');
   if (!fs.existsSync(huskyDir)) fs.mkdirSync(huskyDir);
 

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -172,6 +172,9 @@ function generateWatcher (visitor: Visitor, contracts: any[], config: any, overW
       fs.mkdirSync(outputDir, { recursive: true });
     }
 
+    const huskyDir = path.join(outputDir, '.husky');
+    if (!fs.existsSync(huskyDir)) fs.mkdirSync(huskyDir);
+
     const environmentsFolder = path.join(outputDir, 'environments');
     if (!fs.existsSync(environmentsFolder)) fs.mkdirSync(environmentsFolder);
 
@@ -268,9 +271,6 @@ function generateWatcher (visitor: Visitor, contracts: any[], config: any, overW
     ? fs.createWriteStream(path.join(outputDir, '.npmrc'))
     : process.stdout;
   writeFileToStream(path.join(ASSET_DIR, '.npmrc'), outStream);
-
-  const huskyDir = path.join(outputDir, '.husky');
-  if (!fs.existsSync(huskyDir)) fs.mkdirSync(huskyDir);
 
   outStream = outputDir
     ? fs.createWriteStream(path.join(outputDir, '.husky/pre-commit'))

--- a/packages/codegen/src/indexer.ts
+++ b/packages/codegen/src/indexer.ts
@@ -22,11 +22,15 @@ export class Indexer {
   _events: Array<any>;
   _subgraphEntities: Array<any>;
   _templateString: string;
+  _hasElementaryType: boolean;
+  _hasMappingType: boolean;
 
   constructor () {
     this._queries = [];
     this._events = [];
     this._subgraphEntities = [];
+    this._hasElementaryType = false;
+    this._hasMappingType = false;
     this._templateString = fs.readFileSync(path.resolve(__dirname, TEMPLATE_FILE)).toString();
   }
 
@@ -92,6 +96,15 @@ export class Indexer {
 
     if (stateVariableType) {
       queryObject.stateVariableType = stateVariableType;
+
+      switch (stateVariableType) {
+        case 'ElementaryTypeName':
+          this._hasElementaryType = true;
+          break;
+        case 'Mapping':
+          this._hasMappingType = true;
+          break;
+      }
     }
 
     this._queries.push(queryObject);
@@ -173,6 +186,8 @@ export class Indexer {
       contracts,
       queries: this._queries,
       subgraphEntities: this._subgraphEntities,
+      hasElementaryType: this._hasElementaryType,
+      hasMappingType: this._hasMappingType,
       constants: {
         MODE_ETH_CALL,
         MODE_STORAGE

--- a/packages/codegen/src/indexer.ts
+++ b/packages/codegen/src/indexer.ts
@@ -22,15 +22,15 @@ export class Indexer {
   _events: Array<any>;
   _subgraphEntities: Array<any>;
   _templateString: string;
-  _hasElementaryType: boolean;
-  _hasMappingType: boolean;
+  _hasStateVariableElementaryType: boolean;
+  _hasStateVariableMappingType: boolean;
 
   constructor () {
     this._queries = [];
     this._events = [];
     this._subgraphEntities = [];
-    this._hasElementaryType = false;
-    this._hasMappingType = false;
+    this._hasStateVariableElementaryType = false;
+    this._hasStateVariableMappingType = false;
     this._templateString = fs.readFileSync(path.resolve(__dirname, TEMPLATE_FILE)).toString();
   }
 
@@ -99,10 +99,10 @@ export class Indexer {
 
       switch (stateVariableType) {
         case 'ElementaryTypeName':
-          this._hasElementaryType = true;
+          this._hasStateVariableElementaryType = true;
           break;
         case 'Mapping':
-          this._hasMappingType = true;
+          this._hasStateVariableMappingType = true;
           break;
       }
     }
@@ -186,8 +186,8 @@ export class Indexer {
       contracts,
       queries: this._queries,
       subgraphEntities: this._subgraphEntities,
-      hasElementaryType: this._hasElementaryType,
-      hasMappingType: this._hasMappingType,
+      hasStateVariableElementaryType: this._hasStateVariableElementaryType,
+      hasStateVariableMappingType: this._hasStateVariableMappingType,
       constants: {
         MODE_ETH_CALL,
         MODE_STORAGE

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -257,9 +257,12 @@ export class Schema {
           value: (isArray) ? `[${value}]!` : value,
           proof: () => this._composer.getOTC('Proof')
         });
-      });
+      }
+    );
 
+    // Using this to declare result types before queries
     this._composer.addSchemaMustHaveType(typeComposer);
+
     return typeComposer;
   }
 

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -258,6 +258,8 @@ export class Schema {
           proof: () => this._composer.getOTC('Proof')
         });
       });
+
+    this._composer.addSchemaMustHaveType(typeComposer);
     return typeComposer;
   }
 

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -37,7 +37,7 @@ export const SUBGRAPH_ENTITIES = new Set([
   {{~/each}}]);
 {{/if}}
 export const ENTITIES = [
-  {{~#each queries as | query |}}{{~#if @index }}, {{/if}}{{query.entityName}}{{/each}}
+  {{~#each queries as | query |}}{{query.entityName}}{{#unless @last}}, {{/unless}}{{/each}}{{#if (subgraphPath)}}, {{/if}}
   {{~#if (subgraphPath)}}...SUBGRAPH_ENTITIES{{/if}}];
 {{#if (subgraphPath)}}
 // Map: Entity to suitable query type.

--- a/packages/codegen/src/templates/hooks-template.handlebars
+++ b/packages/codegen/src/templates/hooks-template.handlebars
@@ -5,9 +5,11 @@
 import assert from 'assert';
 
 import {
-  ResultEvent
-  // updateStateForMappingType,
-  // updateStateForElementaryType
+  ResultEvent,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  updateStateForMappingType,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  updateStateForElementaryType
 } from '@cerc-io/util';
 
 import { Indexer } from './indexer';

--- a/packages/codegen/src/templates/hooks-template.handlebars
+++ b/packages/codegen/src/templates/hooks-template.handlebars
@@ -4,7 +4,11 @@
 
 import assert from 'assert';
 
-import { updateStateForMappingType, updateStateForElementaryType, ResultEvent } from '@cerc-io/util';
+import {
+  ResultEvent
+  // updateStateForMappingType,
+  // updateStateForElementaryType
+} from '@cerc-io/util';
 
 import { Indexer } from './indexer';
 

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -3,9 +3,11 @@
 //
 
 import assert from 'assert';
+import { DeepPartial, FindConditions, FindManyOptions{{#if (subgraphPath)}}, ObjectLiteral{{/if}} } from 'typeorm';
+{{#if queries}}
 import debug from 'debug';
-import { DeepPartial, FindConditions, FindManyOptions, ObjectLiteral } from 'typeorm';
 import JSONbig from 'json-bigint';
+{{/if}}
 import { ethers } from 'ethers';
 {{#if (subgraphPath)}}
 import { SelectionNode } from 'graphql';
@@ -23,8 +25,12 @@ import {
   JobQueue,
   Where,
   QueryOptions,
+  {{#if hasElementaryType}}
   updateStateForElementaryType,
+  {{/if}}
+  {{#if hasMappingType}}
   updateStateForMappingType,
+  {{/if}}
   {{#if (subgraphPath)}}
   BlockHeight,
   updateSubgraphState,
@@ -59,9 +65,11 @@ import { {{subgraphEntity.className}} } from './entity/{{subgraphEntity.classNam
 {{#if (subgraphPath)}}
 import { FrothyEntity } from './entity/FrothyEntity';
 {{/if}}
+{{~#if queries}}
 
 const log = debug('vulcanize:indexer');
 const JSONbigNative = JSONbig({ useNativeBigInt: true });
+{{/if}}
 
 {{#each contracts as | contract |}}
 const KIND_{{capitalize contract.contractName}} = '{{contract.contractKind}}';
@@ -178,11 +186,11 @@ export class Indexer implements IndexerInterface {
       };
     }
 
-    {{/unless}}
-    log('{{query.name}}: db miss, fetching from upstream server');
-
     const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
     const blockNumber = ethers.BigNumber.from(number).toNumber();
+
+    {{/unless}}
+    log('{{query.name}}: db miss, fetching from upstream server');
 
     {{#if (compare query.mode @root.constants.MODE_ETH_CALL)}}
     const abi = this._abiMap.get(KIND_{{capitalize query.contract}});
@@ -279,7 +287,7 @@ export class Indexer implements IndexerInterface {
     return createStateCheckpoint(this, contractAddress, blockHash);
   }
 
-  async processCanonicalBlock (blockHash: string, blockNumber: number): Promise<void> {
+  async processCanonicalBlock (blockHash: string{{~#if (subgraphPath)}}, blockNumber: number{{/if}}): Promise<void> {
     console.time('time:indexer#processCanonicalBlock-finalize_auto_diffs');
     // Finalize staged diff blocks if any.
     await this._baseIndexer.finalizeDiffStaged(blockHash);

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -4,8 +4,8 @@
 
 import assert from 'assert';
 import { DeepPartial, FindConditions, FindManyOptions{{#if (subgraphPath)}}, ObjectLiteral{{/if}} } from 'typeorm';
-{{#if queries}}
 import debug from 'debug';
+{{#if queries}}
 import JSONbig from 'json-bigint';
 {{/if}}
 import { ethers } from 'ethers';
@@ -59,15 +59,19 @@ import { SyncStatus } from './entity/SyncStatus';
 import { StateSyncStatus } from './entity/StateSyncStatus';
 import { BlockProgress } from './entity/BlockProgress';
 import { State } from './entity/State';
+{{#if (subgraphPath)}}
+/* eslint-disable @typescript-eslint/no-unused-vars */
 {{#each subgraphEntities as | subgraphEntity |}}
 import { {{subgraphEntity.className}} } from './entity/{{subgraphEntity.className}}';
 {{/each}}
-{{#if (subgraphPath)}}
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
 import { FrothyEntity } from './entity/FrothyEntity';
 {{/if}}
-{{~#if queries}}
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const log = debug('vulcanize:indexer');
+{{#if queries}}
 const JSONbigNative = JSONbig({ useNativeBigInt: true });
 {{/if}}
 

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -25,10 +25,10 @@ import {
   JobQueue,
   Where,
   QueryOptions,
-  {{#if hasElementaryType}}
+  {{#if hasStateVariableElementaryType}}
   updateStateForElementaryType,
   {{/if}}
-  {{#if hasMappingType}}
+  {{#if hasStateVariableMappingType}}
   updateStateForMappingType,
   {{/if}}
   {{#if (subgraphPath)}}

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -10,7 +10,7 @@
     "clean": "rm -rf ./dist",
     "prepare": "husky install",
     "copy-assets": "copyfiles -u 1 src/**/*.gql dist/",
-    "server": "DEBUG=vulcanize:*  YARN_CHILD_PROCESS=true node --enable-source-maps dist/server.js",
+    "server": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true node --enable-source-maps dist/server.js",
     "server:dev": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true ts-node src/server.ts",
     "job-runner": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true node --enable-source-maps dist/job-runner.js",
     "job-runner:dev": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true ts-node src/job-runner.ts",

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -8,6 +8,7 @@
     "lint": "eslint --max-warnings=0 .",
     "build": "yarn clean && tsc && yarn copy-assets",
     "clean": "rm -rf ./dist",
+    "prepare": "husky install",
     "copy-assets": "copyfiles -u 1 src/**/*.gql dist/",
     "server": "DEBUG=vulcanize:*  YARN_CHILD_PROCESS=true node --enable-source-maps dist/server.js",
     "server:dev": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true ts-node src/server.ts",
@@ -72,6 +73,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
+    "husky": "^7.0.2",
     "ts-node": "^10.2.1",
     "typescript": "^5.0.2",
     "copyfiles": "^2.4.1"

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -6,18 +6,25 @@ import assert from 'assert';
 import BigInt from 'apollo-type-bigint';
 import debug from 'debug';
 import Decimal from 'decimal.js';
-import { GraphQLResolveInfo, GraphQLScalarType } from 'graphql';
+import {
+  GraphQLScalarType
+  // GraphQLResolveInfo
+} from 'graphql';
 
 import {
+  {{#if queries}}
   ValueResult,
-  BlockHeight,
+  {{/if}}
   gqlTotalQueryCount,
   gqlQueryCount,
-  jsonBigIntStringReplacer,
   getResultState,
-  setGQLCacheHints,
   IndexerInterface,
+  {{#if (subgraphPath)}}
+  BlockHeight,
+  jsonBigIntStringReplacer,
+  {{/if}}
   EventWatcher
+  // setGQLCacheHints
 } from '@cerc-io/util';
 
 import { Indexer } from './indexer';
@@ -33,7 +40,7 @@ const log = debug('vulcanize:resolver');
 export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher: EventWatcher): Promise<any> => {
   const indexer = indexerArg as Indexer;
 
-  const gqlCacheConfig = indexer.serverConfig.gqlCache;
+  // const gqlCacheConfig = indexer.serverConfig.gqlCache;
 
   return {
     BigInt: new BigInt('bigInt'),
@@ -80,9 +87,9 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
         _: any,
         { blockHash, contractAddress
         {{~#each this.params}}, {{this.name~}} {{/each}} }: { blockHash: string, contractAddress: string
-        {{~#each this.params}}, {{this.name}}: {{this.type~}} {{/each}} },
-        __: any,
-        info: GraphQLResolveInfo
+        {{~#each this.params}}, {{this.name}}: {{this.type~}} {{/each}} }
+        // __: any,
+        // info: GraphQLResolveInfo
       ): Promise<ValueResult> => {
         log('{{this.name}}', blockHash, contractAddress
         {{~#each this.params}}, {{this.name~}} {{/each}});
@@ -101,9 +108,9 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
       {{~#each subgraphQueries}}
       {{this.queryName}}: async (
         _: any,
-        { id, block = {} }: { id: string, block: BlockHeight },
-        __: any,
-        info: GraphQLResolveInfo
+        { id, block = {} }: { id: string, block: BlockHeight }
+        // __: any,
+        // info: GraphQLResolveInfo
       ) => {
         log('{{this.queryName}}', id, JSON.stringify(block, jsonBigIntStringReplacer));
         gqlTotalQueryCount.inc(1);

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -7,8 +7,8 @@ import BigInt from 'apollo-type-bigint';
 import debug from 'debug';
 import Decimal from 'decimal.js';
 import {
-  GraphQLScalarType
-  // GraphQLResolveInfo
+  GraphQLScalarType,
+  GraphQLResolveInfo
 } from 'graphql';
 
 import {
@@ -23,8 +23,9 @@ import {
   BlockHeight,
   jsonBigIntStringReplacer,
   {{/if}}
-  EventWatcher
-  // setGQLCacheHints
+  EventWatcher,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setGQLCacheHints
 } from '@cerc-io/util';
 
 import { Indexer } from './indexer';
@@ -40,7 +41,8 @@ const log = debug('vulcanize:resolver');
 export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher: EventWatcher): Promise<any> => {
   const indexer = indexerArg as Indexer;
 
-  // const gqlCacheConfig = indexer.serverConfig.gqlCache;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const gqlCacheConfig = indexer.serverConfig.gqlCache;
 
   return {
     BigInt: new BigInt('bigInt'),
@@ -87,9 +89,11 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
         _: any,
         { blockHash, contractAddress
         {{~#each this.params}}, {{this.name~}} {{/each}} }: { blockHash: string, contractAddress: string
-        {{~#each this.params}}, {{this.name}}: {{this.type~}} {{/each}} }
-        // __: any,
-        // info: GraphQLResolveInfo
+        {{~#each this.params}}, {{this.name}}: {{this.type~}} {{/each}} },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        __: any,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        info: GraphQLResolveInfo
       ): Promise<ValueResult> => {
         log('{{this.name}}', blockHash, contractAddress
         {{~#each this.params}}, {{this.name~}} {{/each}});
@@ -108,9 +112,9 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
       {{~#each subgraphQueries}}
       {{this.queryName}}: async (
         _: any,
-        { id, block = {} }: { id: string, block: BlockHeight }
-        // __: any,
-        // info: GraphQLResolveInfo
+        { id, block = {} }: { id: string, block: BlockHeight },
+        __: any,
+        info: GraphQLResolveInfo
       ) => {
         log('{{this.queryName}}', id, JSON.stringify(block, jsonBigIntStringReplacer));
         gqlTotalQueryCount.inc(1);


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/39 and https://github.com/cerc-io/watcher-ts/issues/351

- Move result data types before queries in generated watcher GQL schema
- Remove lint warnings in generated watchers
- Flag to overwrite existing watcher in target directory
- Setup pre-commit lint in generated watcher