### PR TITLE
Create queries for only inherited contract methods in codegen generated watchers

### DIFF
--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -154,7 +154,7 @@ function parseAndVisit (visitor: Visitor, contracts: any[], mode: string) {
 
       assert(contractNode);
       const nodes = filterInheritedContractNodes(ast, [contractNode]);
-      ast.children = Array.from(nodes);
+      ast.children = Array.from(nodes).concat(contractNode);
 
       visit(ast, {
         StateVariableDeclaration: stateVariableDeclarationVisitor,

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -14,6 +14,7 @@ import os from 'os';
 
 import { flatten } from '@poanet/solidity-flattener';
 import { parse, visit } from '@solidity-parser/parser';
+import { ASTNode } from '@solidity-parser/parser/dist/src/ast-types';
 import { KIND_ACTIVE, KIND_LAZY } from '@cerc-io/util';
 
 import { MODE_ETH_CALL, MODE_STORAGE, MODE_ALL, MODE_NONE, DEFAULT_PORT } from './utils/constants';
@@ -39,7 +40,6 @@ import { exportIndexBlock } from './index-block';
 import { exportSubscriber } from './subscriber';
 import { exportReset } from './reset';
 import { filterInheritedContractNodes, writeFileToStream } from './utils/helpers';
-import { ASTNode } from '@solidity-parser/parser/dist/src/ast-types';
 
 const ASSET_DIR = path.resolve(__dirname, 'assets');
 
@@ -151,11 +151,9 @@ function parseAndVisit (visitor: Visitor, contracts: any[], mode: string) {
         node.type === 'ContractDefinition' &&
         node.name === contract.contractName
       );
+
       assert(contractNode);
-
-      const nodes: Set<ASTNode> = new Set();
-      filterInheritedContractNodes(ast, [contractNode], nodes);
-
+      const nodes = filterInheritedContractNodes(ast, [contractNode]);
       ast.children = Array.from(nodes);
 
       visit(ast, {

--- a/packages/codegen/src/utils/helpers.ts
+++ b/packages/codegen/src/utils/helpers.ts
@@ -2,6 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
+import { ASTNode, InheritanceSpecifier, SourceUnit } from '@solidity-parser/parser/dist/src/ast-types';
 import fs from 'fs';
 import { Writable } from 'stream';
 import { TypeName } from '@solidity-parser/parser/dist/src/ast-types';
@@ -21,4 +22,21 @@ export const getBaseType = (typeName: TypeName): string | undefined => {
 export function writeFileToStream (pathToFile: string, outStream: Writable): void {
   const fileStream = fs.createReadStream(pathToFile);
   fileStream.pipe(outStream);
+}
+
+export function filterInheritedContractNodes (ast: SourceUnit, contractNodes: ASTNode[], importedNodes: Set<ASTNode>): void {
+  contractNodes.forEach((node: ASTNode) => {
+    if (node.type !== 'ContractDefinition') return;
+
+    const inheritedContracts = ast.children.filter((childNode: ASTNode) =>
+      childNode.type === 'ContractDefinition' &&
+      childNode.kind !== 'library' &&
+      node.baseContracts.some((baseContract: InheritanceSpecifier) =>
+        baseContract.baseName.namePath === childNode.name
+      )
+    );
+
+    inheritedContracts.forEach((node: ASTNode) => importedNodes.add(node));
+    filterInheritedContractNodes(ast, inheritedContracts, importedNodes);
+  });
 }


### PR DESCRIPTION
Part of #351 