### PR TITLE
[WIP] Support DB caching for multiple return types in eth_call queries

### DIFF
--- a/packages/codegen/src/indexer.ts
+++ b/packages/codegen/src/indexer.ts
@@ -57,8 +57,7 @@ export class Indexer {
       return;
     }
 
-    // Disable DB caching if more than 1 return params.
-    let disableCaching = returnParameters.length > 1;
+    let disableCaching = false;
 
     const returnTypes = returnParameters.map(returnParameter => {
       let typeName = returnParameter.typeName;

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -185,7 +185,15 @@ export class Indexer implements IndexerInterface {
       log('{{query.name}}: db hit.');
 
       return {
+        {{~#if (compare query.returnTypes.length 1 operator=">")}}
+        value: {
+          {{#each query.returnTypes}}
+          value{{@index}}: entity.value{{@index}}{{#unless @last}},{{/unless}}
+          {{/each}}
+        },
+        {{else}}
         value: entity.value,
+        {{/if}}
         proof: JSON.parse(entity.proof)
       };
     }
@@ -249,8 +257,20 @@ export class Indexer implements IndexerInterface {
     {{/if}}
 
     {{#unless disableCaching}}
-    await this._db.{{query.saveQueryName}}({ blockHash, blockNumber, contractAddress
-    {{~#each query.params}}, {{this.name~}} {{/each}}, value: result.value, proof: JSONbigNative.stringify(result.proof) });
+    await this._db.{{query.saveQueryName}}({
+      blockHash,
+      blockNumber,
+      contractAddress,
+      {{~#each query.params}}{{this.name~}},{{/each}}
+      {{#each query.returnTypes}}
+      {{~#if (compare query.returnTypes.length 1 operator=">")}}
+      value{{@index}}: result.value.value{{@index}},
+      {{else}}
+      value: result.value,
+      {{/if}}
+      {{/each}}
+      proof: JSONbigNative.stringify(result.proof)
+    });
 
     {{/unless}}
     {{#if query.stateVariableType}}

--- a/packages/codegen/src/visitor.ts
+++ b/packages/codegen/src/visitor.ts
@@ -74,19 +74,20 @@ export class Visitor {
     const typeName = node.returnParameters[0].typeName;
     assert(typeName);
 
+    // TODO: Check for unhandled return type params
+
     switch (typeName.type) {
       case 'ElementaryTypeName':
-        this._entity.addQuery(name, params, typeName);
-        this._database.addQuery(name, params, typeName);
-        this._client.addQuery(name, params, typeName);
         // falls through
 
       case 'ArrayTypeName':
         this._schema.addQuery(name, params, node.returnParameters);
         this._resolvers.addQuery(name, params);
-
         assert(this._contract);
         this._indexer.addQuery(this._contract.name, MODE_ETH_CALL, name, params, node.returnParameters);
+        this._entity.addQuery(name, params, node.returnParameters);
+        this._database.addQuery(name, params, typeName);
+        this._client.addQuery(name, params, typeName);
         break;
 
       case 'UserDefinedTypeName':
@@ -149,12 +150,11 @@ export class Visitor {
       case 'ElementaryTypeName': {
         this._schema.addQuery(name, params, [variable]);
         this._resolvers.addQuery(name, params);
-        this._entity.addQuery(name, params, typeName);
-        this._database.addQuery(name, params, typeName);
-        this._client.addQuery(name, params, typeName);
-
         assert(this._contract);
         this._indexer.addQuery(this._contract.name, MODE_STORAGE, name, params, [variable], stateVariableType);
+        this._entity.addQuery(name, params, [variable]);
+        this._database.addQuery(name, params, typeName);
+        this._client.addQuery(name, params, typeName);
 
         break;
       }


### PR DESCRIPTION
Part of #351 

- Generate DB caching code in indexer file for multiple return types
- Generate entities for multiple return type queries