### PR TITLE
Fix watch contract to update checksum address in `stateStatusMap`

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -37,7 +37,7 @@ Steps:
     - name: Example
       # Contract file path or an url.
       path: ../graph-node/test/contracts/Example.sol
-      # Contract kind (should match that in {subgraphPath}/subgraph.yaml if subgraphPath provided)
+      # Contract kind (should match name of dataSource in {subgraphPath}/subgraph.yaml if subgraphPath provided)
       kind: Example1
 
   # Output folder path (logs output using `stdout` if not provided).

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -553,6 +553,10 @@ export class Schema {
       param = utils.ParamType.fromObject({ type: 'bytes32', name: param.name });
     }
 
+    // TODO: Get type name for tuple base types
+    // ethers.utils gives both param.type and param.baseType as 'tuple', but doesn't give the actual type name
+    // represented by 'internalType' field in the ABI
+    // eg. "internalType": "struct Provider" or "internalType": "struct Task[]"
     if (param.baseType === 'tuple') {
       const typeName = param.name.charAt(0).toUpperCase() + param.name.slice(1);
       return this._createObjectType(typeName, param.components);

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -4,7 +4,7 @@
 
 import assert from 'assert';
 import { GraphQLSchema, parse, printSchema, print, GraphQLDirective, GraphQLInt, GraphQLBoolean } from 'graphql';
-import { ObjectTypeComposer, ObjectTypeComposerDefinition, ObjectTypeComposerFieldConfigMapDefinition, SchemaComposer } from 'graphql-compose';
+import { ObjectTypeComposer, NonNullComposer, ObjectTypeComposerDefinition, ObjectTypeComposerFieldConfigMapDefinition, SchemaComposer } from 'graphql-compose';
 import { Writable } from 'stream';
 import { utils } from 'ethers';
 import { VariableDeclaration } from '@solidity-parser/parser/dist/src/ast-types';
@@ -519,7 +519,7 @@ export class Schema {
   }
 
   /**
-   * Create GraphQL schmea object type.
+   * Create GraphQL schema object type.
    * @param name
    * @param params
    */
@@ -547,7 +547,7 @@ export class Schema {
      * Get type of field in GraphQL schema for object types.
      * @param param
      */
-  _getObjectTypeField (param: utils.ParamType): ObjectTypeComposer | string | any[] {
+  _getObjectTypeField (param: utils.ParamType): NonNullComposer<ObjectTypeComposer> | string | any[] {
     if (param.indexed && ['string', 'bytes', 'tuple', 'array'].includes(param.baseType)) {
       // Check for indexed reference type event params.
       param = utils.ParamType.fromObject({ type: 'bytes32', name: param.name });
@@ -559,7 +559,7 @@ export class Schema {
     // eg. "internalType": "struct Provider" or "internalType": "struct Task[]"
     if (param.baseType === 'tuple') {
       const typeName = param.name.charAt(0).toUpperCase() + param.name.slice(1);
-      return this._createObjectType(typeName, param.components);
+      return this._createObjectType(typeName, param.components).NonNull;
     }
 
     if (param.baseType === 'array') {

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,7 +41,6 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@ethersproject/providers": "^5.4.4",
     "@cerc-io/cli": "^0.2.41",
     "@cerc-io/ipld-eth-client": "^0.2.41",
     "@cerc-io/solidity-mapper": "^0.2.41",
@@ -49,23 +48,25 @@
     {{#if (subgraphPath)}}
     "@cerc-io/graph-node": "^0.2.41",
     {{/if}}
+    "@ethersproject/providers": "^5.4.4",
     "apollo-type-bigint": "^0.1.3",
     "debug": "^4.3.1",
+    "decimal.js": "^10.3.1",
     "ethers": "^5.4.4",
     "graphql": "^15.5.0",
     "json-bigint": "^1.0.0",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.32",
-    "yargs": "^17.0.1",
-    "decimal.js": "^10.3.1"
+    "yargs": "^17.0.1"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.3.0",
-    "@types/yargs": "^17.0.0",
     "@types/debug": "^4.1.5",
     "@types/json-bigint": "^1.0.0",
+    "@types/yargs": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
+    "copyfiles": "^2.4.1",
     "eslint": "^8.35.0",
     "eslint-config-semistandard": "^15.0.1",
     "eslint-config-standard": "^16.0.3",
@@ -75,7 +76,6 @@
     "eslint-plugin-standard": "^5.0.0",
     "husky": "^7.0.2",
     "ts-node": "^10.2.1",
-    "typescript": "^5.0.2",
-    "copyfiles": "^2.4.1"
+    "typescript": "^5.0.2"
   }
 }

--- a/packages/codegen/subgraph-demo.md
+++ b/packages/codegen/subgraph-demo.md
@@ -43,7 +43,7 @@
     - name: Example
       # Contract file path or an url.
       path: ../graph-node/test/contracts/Example.sol
-      # Contract kind (should match that in {subgraphPath}/subgraph.yaml if subgraphPath provided)
+      # Contract kind (should match name of dataSource in {subgraphPath}/subgraph.yaml if subgraphPath provided)
       kind: Example1
 
   # Output folder path (logs output using `stdout` if not provided).
@@ -213,5 +213,5 @@
     * A `checkpoint` state should be created at the latest canonical block hash.
 
     * Run the `getState` query again at the endpoint with the output `blockHash` and kind `checkpoint`.
-  
+
 * All the `State` entries can be seen in `pg-admin` in table `state`.

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -515,13 +515,14 @@ export class Indexer {
 
   async watchContract (address: string, kind: string, checkpoint: boolean, startingBlock: number): Promise<void> {
     assert(this._db.saveContract);
-    this.updateStateStatusMap(address, {});
-    const dbTx = await this._db.createTransactionRunner();
 
     // Use the checksum address (https://docs.ethers.io/v5/api/utils/address/#utils-getAddress) if input to address is a contract address.
     // If a contract identifier is passed as address instead, no need to convert to checksum address.
     // Customize: use the kind input to filter out non-contract-address input to address.
     const contractAddress = (kind === '__protocol__') ? address : ethers.utils.getAddress(address);
+
+    this.updateStateStatusMap(contractAddress, {});
+    const dbTx = await this._db.createTransactionRunner();
 
     try {
       const contract = await this._db.saveContract(dbTx, contractAddress, kind, checkpoint, startingBlock);


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/375

- Error is thrown on using a non checksum address for watching contract
  - Fixed by using converting to checksum address before updating `stateStatusMap`
- Use non-null object type composer for object types to make corresponding fields in the generated GQL schema "required"