### PR TITLE
Add yamux stream multiplexer in peer package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.57",
+  "version": "0.2.58",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.57",
-    "@cerc-io/ipld-eth-client": "^0.2.57",
+    "@cerc-io/cache": "^0.2.58",
+    "@cerc-io/ipld-eth-client": "^0.2.58",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.10",
-    "@cerc-io/peer": "^0.2.57",
-    "@cerc-io/rpc-eth-client": "^0.2.57",
-    "@cerc-io/util": "^0.2.57",
+    "@cerc-io/peer": "^0.2.58",
+    "@cerc-io/rpc-eth-client": "^0.2.58",
+    "@cerc-io/util": "^0.2.58",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.57",
+    "@cerc-io/util": "^0.2.58",
     "@graphql-tools/load-files": "^6.5.2",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",
     "@solidity-parser/parser": "^0.13.2",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.57",
+    "@cerc-io/solidity-mapper": "^0.2.58",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.57",
-    "@cerc-io/ipld-eth-client": "^0.2.57",
-    "@cerc-io/util": "^0.2.57",
+    "@cerc-io/cache": "^0.2.58",
+    "@cerc-io/ipld-eth-client": "^0.2.58",
+    "@cerc-io/util": "^0.2.58",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.57",
+    "@cerc-io/cache": "^0.2.58",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -32,6 +32,7 @@
     "@cerc-io/prometheus-metrics": "1.1.4",
     "@chainsafe/libp2p-gossipsub": "^6.0.0",
     "@chainsafe/libp2p-noise": "^11.0.0",
+    "@chainsafe/libp2p-yamux": "3.0.7",
     "@libp2p/floodsub": "^6.0.0",
     "@libp2p/mplex": "^7.1.1",
     "@libp2p/peer-id-factory": "^2.0.0",

--- a/packages/peer/src/peer.ts
+++ b/packages/peer/src/peer.ts
@@ -16,6 +16,7 @@ import { createLibp2p, Libp2p, Libp2pInit } from '@cerc-io/libp2p';
 import { webSockets } from '@libp2p/websockets';
 import { noise } from '@chainsafe/libp2p-noise';
 import { mplex } from '@libp2p/mplex';
+import { yamux } from '@chainsafe/libp2p-yamux';
 import type { Stream as P2PStream, Connection } from '@libp2p/interface-connection';
 import type { PeerInfo } from '@libp2p/interface-peer-info';
 import type { Message } from '@libp2p/interface-pubsub';
@@ -156,7 +157,7 @@ export class Peer {
           listen: initOptions.listenMultiaddrs ?? []
         },
         connectionEncryption: [noise()],
-        streamMuxers: [mplex()],
+        streamMuxers: [mplex(), yamux()],
         pubsub: initPubsub(initOptions.pubsub),
         peerDiscovery: [
           // Use pubsub based discovery; relay server acts as a peer discovery source

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.57",
-    "@cerc-io/ipld-eth-client": "^0.2.57",
-    "@cerc-io/util": "^0.2.57",
+    "@cerc-io/cache": "^0.2.58",
+    "@cerc-io/ipld-eth-client": "^0.2.58",
+    "@cerc-io/util": "^0.2.58",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/ipld-eth-client": "^0.2.57",
+    "@cerc-io/ipld-eth-client": "^0.2.58",
     "@ethersproject/abi": "^5.3.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.10",
-    "@cerc-io/peer": "^0.2.57",
-    "@cerc-io/solidity-mapper": "^0.2.57",
+    "@cerc-io/peer": "^0.2.58",
+    "@cerc-io/solidity-mapper": "^0.2.58",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/schema": "^9.0.10",
@@ -49,7 +49,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.57",
+    "@cerc-io/cache": "^0.2.58",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,6 +477,21 @@
     uint8arraylist "^2.3.2"
     uint8arrays "^4.0.2"
 
+"@chainsafe/libp2p-yamux@3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-yamux/-/libp2p-yamux-3.0.7.tgz#345d620097c6ac07fcbeb5910da18b3ed974337c"
+  integrity sha512-fp59/7Xzws+4Nz4TUS+5Z/lkwk+9IW6GsU6wPJVaGInxf5tl4qQ5S8TLql23CEGbuvbToqMEdNLVAtE+M2Lvng==
+  dependencies:
+    "@libp2p/interface-connection" "^3.0.1"
+    "@libp2p/interface-stream-muxer" "^3.0.0"
+    "@libp2p/interfaces" "^3.2.0"
+    "@libp2p/logger" "^2.0.1"
+    abortable-iterator "^4.0.2"
+    any-signal "^3.0.1"
+    it-pipe "^2.0.4"
+    it-pushable "^3.1.0"
+    uint8arraylist "^2.3.2"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -4576,7 +4591,7 @@ any-promise@^1.0.0:
   resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
-any-signal@^3.0.0:
+any-signal@^3.0.0, any-signal@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/any-signal/-/any-signal-3.0.1.tgz#49cae34368187a3472e31de28fb5cb1430caa9a6"
   integrity sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386

- Added yamux to support connection with go-nitro
  - go-nitro has stopped using `mplex` as it is [deprecated](https://github.com/libp2p/specs/issues/553)