### PR TITLE
Add validation methods for watcher config

### DIFF
--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -194,7 +194,7 @@ export interface ServerConfig {
   port: number;
   mode: string;
   kind: string;
-  enableValidation: boolean;
+  enableConfigValidation: boolean;
   checkpointing: boolean;
   checkpointInterval: number;
   subgraphPath: string;

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -194,6 +194,7 @@ export interface ServerConfig {
   port: number;
   mode: string;
   kind: string;
+  enableValidation: boolean;
   checkpointing: boolean;
   checkpointInterval: number;
   subgraphPath: string;

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -28,4 +28,4 @@ export const DEFAULT_PREFETCH_BATCH_SIZE = 10;
 
 export const DEFAULT_MAX_GQL_CACHE_SIZE = Math.pow(2, 20) * 8; // 8 MB
 
-export const VALID_ETH_RPC_METHODS = ['eth_getBlockByHash', 'eth_getStorageAt', 'eth_getBlockByNumber'];
+export const SUPPORTED_PAID_RPC_METHODS = ['eth_getBlockByHash', 'eth_getStorageAt', 'eth_getBlockByNumber'];

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -27,3 +27,5 @@ export const KIND_LAZY = 'lazy';
 export const DEFAULT_PREFETCH_BATCH_SIZE = 10;
 
 export const DEFAULT_MAX_GQL_CACHE_SIZE = Math.pow(2, 20) * 8; // 8 MB
+
+export const VALID_ETH_RPC_METHODS = ['eth_getBlockByHash', 'eth_getStorageAt', 'eth_getBlockByNumber'];

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -26,3 +26,4 @@ export * from './graph/types';
 export * from './payments';
 export * from './eth';
 export * from './consensus';
+export * from './validate-config';

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -31,9 +31,9 @@ async function validateContractDeployment (rpcEndpoint: string, contractInfo: {a
 
 function validateContractAddressFormat (contractInfo: {address:string, name?:string}): void {
   if (ethers.utils.isAddress(contractInfo.address)) {
-    log(`SUCCESS: The ${contractInfo.name ? contractInfo.name : 'contract'} ${contractInfo.address} is in a valid format`);
+    log(`SUCCESS: Address ${contractInfo.address} ${contractInfo.name ? `for ${contractInfo.name}` : ''} is in a valid format`);
   } else {
-    log(`WARNING: The ${contractInfo.name ? contractInfo.name : 'contract'} ${contractInfo.address} is not in a valid format`);
+    log(`WARNING: Address ${contractInfo.address} ${contractInfo.name ? `for ${contractInfo.name}` : ''} is not in a valid format`);
   }
 }
 

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -29,18 +29,23 @@ async function validateContractDeployment (rpcEndpoint: string, contractInfo: {a
   }
 }
 
-function validateContractAddressFormat (contractInfo: {address:string, name?:string}): void {
+function validateContractAddressFormat (contractInfo: {address:string, name?:string}): boolean {
   if (ethers.utils.isAddress(contractInfo.address)) {
     log(`SUCCESS: Address ${contractInfo.address} ${contractInfo.name ? `for ${contractInfo.name}` : ''} is in a valid format`);
+    return true;
   } else {
     log(`WARNING: Address ${contractInfo.address} ${contractInfo.name ? `for ${contractInfo.name}` : ''} is not in a valid format`);
+    return false;
   }
 }
 
 export async function validateContracts (contractsArr: {address:string, name?:string}[], rpcProviderMutationEndpoint: string, isWs: boolean): Promise<void> {
   contractsArr.forEach((contract) => {
-    validateContractAddressFormat(contract);
-    validateContractDeployment(rpcProviderMutationEndpoint, contract, isWs);
+    const isValidFormat = validateContractAddressFormat(contract);
+
+    if (isValidFormat) {
+      validateContractDeployment(rpcProviderMutationEndpoint, contract, isWs);
+    }
   });
 }
 

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -68,7 +68,7 @@ async function checkDBEndpoint (connectionString: string, dbKind: string): Promi
     await client.connect();
     log(`SUCCESS: ${dbKind} endpoint is up!`);
   } catch (error) {
-    log('WARNING: Error connecting to job queue database. Please check if job queue config is setup and database is running \n', error);
+    log(`WARNING: Error connecting to ${dbKind} database. Please check if job queue config is setup and database is running \n`, error);
   } finally {
     await client.end();
   }
@@ -101,7 +101,7 @@ async function checkWebSocket (wsEndpoint: string) {
 export async function validateWebSocketEndpoint (wsEndpoint: string): Promise<void> {
   try {
     await checkWebSocket(wsEndpoint);
-    log(`The WebSocket endpoint ${wsEndpoint} is running.`);
+    log(`SUCCESS: The WebSocket endpoint ${wsEndpoint} is running.`);
   } catch (error) {
     log(`WARNING: Error connecting to websocket endpoint ${wsEndpoint}. Please check if server.p2p.nitro.chainUrl is correct.`, error);
   }
@@ -110,7 +110,7 @@ export async function validateWebSocketEndpoint (wsEndpoint: string): Promise<vo
 export async function validatePaidRPCMethods (paidRPCMethods: string[]): Promise<void> {
   paidRPCMethods.forEach((method) => {
     if (SUPPORTED_PAID_RPC_METHODS.includes(method)) {
-      log(`SUCESS: ${method} is a supported paid RPC method`);
+      log(`SUCCESS: ${method} is a supported paid RPC method`);
     } else {
       log(`WARNING: ${method} is not a supported paid RPC method`);
     }

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -109,9 +109,9 @@ export async function validateWebSocketEndpoint (wsEndpoint: string): Promise<vo
 export async function validatePaidRPCMethods (paidRPCMethods: string[]): Promise<void> {
   paidRPCMethods.forEach((method) => {
     if (SUPPORTED_PAID_RPC_METHODS.includes(method)) {
-      log(`SUCESS: ${method} is a valid JsonRpcMethod`);
+      log(`SUCESS: ${method} is a supported paid RPC method`);
     } else {
-      log(`WARNING: ${method} is not a valid JsonRpcMethod`);
+      log(`WARNING: ${method} is not a supported paid RPC method`);
     }
   });
 }

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -52,11 +52,7 @@ export async function validateContracts (contractsArr: {address:string, name?:st
 export async function validateHttpEndpoint (endPoint: string, kind: string): Promise<void> {
   try {
     const response = await fetch(endPoint);
-    if (!response.ok) {
-      log(`WARNING: HTTP error! for endpoint ${endPoint} Status: ${response.status}`);
-    } else {
-      log(`SUCCESS: The ${endPoint} is up`);
-    }
+    log(`SUCCESS: The ${endPoint} is up. Status ${response.status}`);
   } catch (error:any) {
     log(`WARNING: could not connect to ${endPoint}. Please check if the ${kind} is correct and up.`);
     log(error);

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -1,0 +1,110 @@
+import { ethers } from 'ethers';
+import { Client } from 'pg';
+import debug from 'debug';
+import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import WebSocket from 'ws';
+
+import { VALID_ETH_RPC_METHODS } from './constants';
+
+const log = debug('vulcanize:server');
+
+async function validateContractDeployment (rpcEndpoint: string, contractAddress: string): Promise<void> {
+  try {
+    const provider = await new ethers.providers.JsonRpcProvider(rpcEndpoint);
+    const code = await provider.getCode(contractAddress);
+    if (code === '0x') {
+      log(`WARNING: Contract is not deployed at address ${contractAddress}`);
+    } else {
+      log(`SUCCESS: Contract is deployed at address ${contractAddress}`);
+    }
+  } catch (error) {
+    log(error);
+  }
+}
+
+function validateContractAddressFormat (contractAddress: string): void {
+  if (ethers.utils.isAddress(contractAddress)) {
+    log(`SUCCESS: Given contract address ${contractAddress} is in a valid format`);
+  } else {
+    log(`WARNING: Given contract address ${contractAddress} is not in a valid format`);
+  }
+}
+
+export async function validateContracts (contractsArr: string[], rpcProviderMutationEndpoint: string): Promise<void> {
+  contractsArr.forEach((contractAddr: string) => {
+    validateContractAddressFormat(contractAddr);
+    validateContractDeployment(rpcProviderMutationEndpoint, contractAddr);
+  });
+}
+
+export async function validateEndpoint (endPoint: string, kind: string): Promise<void> {
+  try {
+    const response = await fetch(endPoint);
+    if (!response.ok) {
+      log(`WARNING: HTTP error! Status: ${response.status}`);
+    } else {
+      log(`SUCCESS: The ${endPoint} is up`);
+    }
+  } catch (error:any) {
+    log(`WARNING: could not connect to ${endPoint}. Please check if the ${kind} is correct and up.`);
+    log(error);
+  }
+}
+
+async function checkDBEndpoint (connectionString: string, dbKind: string): Promise<void> {
+  const client = new Client({
+    connectionString
+  });
+
+  try {
+    await client.connect();
+    log(`SUCCESS: ${dbKind} endpoint is up!`);
+  } catch (error) {
+    log('WARNING: Error connecting to job queue database. Please check if job queue config is setup and database is running \n', error);
+  } finally {
+    await client.end();
+  }
+}
+
+export async function validateDatabaseEndpoint (database: PostgresConnectionOptions): Promise<void> {
+  const connectionString = `${database.type}://${database.username}:${database.password}@${database.host}:${database.port}/${database.database}`;
+  await checkDBEndpoint(connectionString, 'postgresQL');
+}
+
+export async function validateJobQueueEndpoint (connString: string): Promise<void> {
+  await checkDBEndpoint(connString, 'Job queue database');
+}
+
+async function checkWebSocket (wsEndpoint: string) {
+  const socket = new WebSocket(wsEndpoint);
+
+  return new Promise((resolve, reject) => {
+    socket.on('open', () => {
+      socket.close();
+      resolve(true);
+    });
+
+    socket.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+export async function validateNitroChainUrl (wsEndpoint: string): Promise<void> {
+  try {
+    await checkWebSocket(wsEndpoint);
+    log(`The WebSocket endpoint ${wsEndpoint} is running.`);
+  } catch (error) {
+    log(`WARNING: Error connecting to websocket endpoint ${wsEndpoint}. Please check if server.p2p.nitro.chainUrl is correct.`, error);
+  }
+}
+
+export async function validateEthRPCMethods (paidRPCMethods: string[]): Promise<void> {
+  paidRPCMethods.forEach((method) => {
+    if (VALID_ETH_RPC_METHODS.includes(method)) {
+      log(`SUCESS: ${method} is a valid JsonRpcMethod`);
+    } else {
+      log(`WARNING: ${method} is not a valid JsonRpcMethod`);
+    }
+  });
+}

--- a/packages/util/src/validate-config.ts
+++ b/packages/util/src/validate-config.ts
@@ -66,7 +66,7 @@ async function checkDBEndpoint (connectionString: string, dbKind: string): Promi
 
   try {
     await client.connect();
-    log(`SUCCESS: ${dbKind} endpoint is up!`);
+    log(`SUCCESS: ${dbKind} endpoint is up.`);
   } catch (error) {
     log(`WARNING: Error connecting to ${dbKind} database. Please check if job queue config is setup and database is running \n`, error);
   } finally {
@@ -101,7 +101,7 @@ async function checkWebSocket (wsEndpoint: string) {
 export async function validateWebSocketEndpoint (wsEndpoint: string): Promise<void> {
   try {
     await checkWebSocket(wsEndpoint);
-    log(`SUCCESS: The WebSocket endpoint ${wsEndpoint} is running.`);
+    log(`SUCCESS: The WebSocket endpoint ${wsEndpoint} is up.`);
   } catch (error) {
     log(`WARNING: Error connecting to websocket endpoint ${wsEndpoint}. Please check if server.p2p.nitro.chainUrl is correct.`, error);
   }


### PR DESCRIPTION
Part of [Better config checking and logging errors on watcher start](https://www.notion.so/Better-config-checking-and-error-logging-on-watcher-start-774fa6fb1dc44410a362877ba698e9e1)

- Add validation methods for:
  - Validating HTTP endpoints
  - Validating Nitro chain URL (WS endpoint)
  - Validating contracts
  - Validating Postgres DB
  - Validating paid RPC methods