### PR TITLE
Upgrade nitro-node dependency

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.65",
+  "version": "0.2.66",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "@cerc-io/cache": "^0.2.65",
     "@cerc-io/ipld-eth-client": "^0.2.65",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
-    "@cerc-io/nitro-node": "^0.1.14",
+    "@cerc-io/nitro-node": "^0.1.15",
     "@cerc-io/peer": "^0.2.65",
     "@cerc-io/rpc-eth-client": "^0.2.65",
     "@cerc-io/util": "^0.2.65",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.65",
-    "@cerc-io/ipld-eth-client": "^0.2.65",
+    "@cerc-io/cache": "^0.2.66",
+    "@cerc-io/ipld-eth-client": "^0.2.66",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.65",
-    "@cerc-io/rpc-eth-client": "^0.2.65",
-    "@cerc-io/util": "^0.2.65",
+    "@cerc-io/peer": "^0.2.66",
+    "@cerc-io/rpc-eth-client": "^0.2.66",
+    "@cerc-io/util": "^0.2.66",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -254,7 +254,7 @@ export class ServerCmd {
       nitroContractAddresses,
       this.peer,
       true,
-      path.resolve(nitroConfig.store)
+      path.resolve(nitroConfig.store || './out/nitro-data')
     );
 
     log(`Nitro node started with address: ${this._nitro.node.address}`);

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.65",
+    "@cerc-io/util": "^0.2.66",
     "@graphql-tools/load-files": "^6.5.2",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",
     "@solidity-parser/parser": "^0.13.2",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.65",
+    "@cerc-io/solidity-mapper": "^0.2.66",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.65",
-    "@cerc-io/ipld-eth-client": "^0.2.65",
-    "@cerc-io/util": "^0.2.65",
+    "@cerc-io/cache": "^0.2.66",
+    "@cerc-io/ipld-eth-client": "^0.2.66",
+    "@cerc-io/util": "^0.2.66",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.65",
+    "@cerc-io/cache": "^0.2.66",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.65",
-    "@cerc-io/ipld-eth-client": "^0.2.65",
-    "@cerc-io/util": "^0.2.65",
+    "@cerc-io/cache": "^0.2.66",
+    "@cerc-io/ipld-eth-client": "^0.2.66",
+    "@cerc-io/util": "^0.2.66",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/ipld-eth-client": "^0.2.65",
+    "@cerc-io/ipld-eth-client": "^0.2.66",
     "@ethersproject/abi": "^5.3.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.65",
-    "@cerc-io/solidity-mapper": "^0.2.65",
+    "@cerc-io/peer": "^0.2.66",
+    "@cerc-io/solidity-mapper": "^0.2.66",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -51,7 +51,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.65",
+    "@cerc-io/cache": "^0.2.66",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
-    "@cerc-io/nitro-node": "^0.1.14",
+    "@cerc-io/nitro-node": "^0.1.15",
     "@cerc-io/peer": "^0.2.65",
     "@cerc-io/solidity-mapper": "^0.2.65",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,20 +350,20 @@
     wherearewe "^2.0.0"
     xsalsa20 "^1.1.0"
 
-"@cerc-io/nitro-node@^0.1.14":
-  version "0.1.14"
-  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-node/-/0.1.14/nitro-node-0.1.14.tgz#9439f56aab562ea8809b923302c6b8f0be472f4e"
-  integrity sha512-eZuG4+tuWul+UkxiQ+sOYmaYS7M8LmuxKLn5tWRuURXo9l1ynxkoovPDTte3obuuGDITGJTdOvVFZtOs6ryKtw==
+"@cerc-io/nitro-node@^0.1.15":
+  version "0.1.15"
+  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-node/-/0.1.15/nitro-node-0.1.15.tgz#c36c48591fd5615768cf31eb17510b86f232bd49"
+  integrity sha512-wE8tWD7m8lZ3TEMnaI19YOiJLA8Sm9UOHsPKzzjCE2xIJ0X5HmSW4qi6BJEGd8VnlFGbBDXzG+O2DBYUWRpi2g==
   dependencies:
     "@cerc-io/libp2p" "0.42.2-laconic-0.1.4"
-    "@cerc-io/nitro-util" "^0.1.14"
-    "@cerc-io/peer" "^0.2.60"
+    "@cerc-io/nitro-util" "^0.1.15"
+    "@cerc-io/peer" "^0.2.65"
     "@cerc-io/ts-channel" "1.0.3-ts-nitro-0.1.1"
     "@jpwilliams/waitgroup" "^2.1.0"
     "@libp2p/crypto" "^1.0.4"
     "@libp2p/tcp" "^6.0.0"
     "@multiformats/multiaddr" "^11.1.4"
-    "@statechannels/nitro-protocol" "^2.0.0-alpha.5"
+    "@statechannels/nitro-protocol" "^2.0.1-alpha.5"
     assert "^2.0.0"
     async-mutex "^0.4.0"
     debug "^4.3.4"
@@ -376,13 +376,13 @@
     promjs "^0.4.2"
     uint8arrays "^4.0.3"
 
-"@cerc-io/nitro-util@^0.1.14":
-  version "0.1.14"
-  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-util/-/0.1.14/nitro-util-0.1.14.tgz#6ee1b2f95c3fc64bf73f8be0a2bd4f9ede823085"
-  integrity sha512-LnrTWzSaWwH4SBY1KtsKIdDpIkH8jhR9rr3VX5w9UWbXO8vgw+SmJFiVY+xRglVE/YRJvfofyUDKuCXBGsKrgw==
+"@cerc-io/nitro-util@^0.1.15":
+  version "0.1.15"
+  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-util/-/0.1.15/nitro-util-0.1.15.tgz#693dcb9642ebab490f9c2088fbe490fb6ecfb438"
+  integrity sha512-ByFq+Ne8dUp2omvm2Wui19r22CvXmdIJeAnN+8BhCU/B0e01zHgPhoaoQ3FX5F/NFG7+eiuFHpVdmBRq+cbnUA==
   dependencies:
     "@cerc-io/ts-channel" "1.0.3-ts-nitro-0.1.1"
-    "@statechannels/nitro-protocol" "^2.0.0-alpha.5"
+    "@statechannels/nitro-protocol" "^2.0.1-alpha.5"
     assert "^2.0.0"
     debug "^4.3.4"
     ethers "^5.7.2"
@@ -3752,10 +3752,10 @@
     ethers "^5.1.4"
     lodash "^4.17.21"
 
-"@statechannels/nitro-protocol@^2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@statechannels/nitro-protocol/-/nitro-protocol-2.0.0-alpha.5.tgz#9b51ee8170de9f51816144c06f568199ccab3237"
-  integrity sha512-b4rlq0D97MidlKL3MxOsn1Rtl5VzH26xyvVSe8iZXapUdpYfsIH8Nj5PqVki7drFJWVYjVTjwDwc5pvRW8jNbg==
+"@statechannels/nitro-protocol@^2.0.1-alpha.5":
+  version "2.0.1-alpha.5"
+  resolved "https://registry.yarnpkg.com/@statechannels/nitro-protocol/-/nitro-protocol-2.0.1-alpha.5.tgz#3aa09dacf6780a47ff415de23123f9aafe2534ec"
+  integrity sha512-CT32i5ZlZ0Jz8mAOmywALCnS/+Cl7ntrRlJr2r3jGBkkzNBWxHWR4qXg6HTUh7xxm5tY/g/TSmsGH8/z54K/Sw==
   dependencies:
     "@openzeppelin/contracts" "^4.7.3"
     "@statechannels/exit-format" "^0.2.0"


### PR DESCRIPTION
Part of [Upgrade go-nitro to v0.1.2-ts-port-0.1.9 and ts-nitro to v0.1.15 in the stack](https://www.notion.so/Upgrade-go-nitro-to-v0-1-2-ts-port-0-1-9-and-ts-nitro-to-v0-1-15-in-the-stack-ba300986e92e4f198c72c46a1861d8e4)