### PR TITLE
Update codegen readme for compiling subgraph WASM using cerc-io packages

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -62,6 +62,8 @@ Steps:
 
   # Path to the subgraph build (optional).
   # Can set empty contracts array when using subgraphPath.
+  # Subgraph WASM files should be compiled using @cerc-io/graph-cli
+  # graph-cli and graph-ts dependencies in the target subgraph repo can be replaced with forked cerc-io packages
   subgraphPath: ../graph-node/test/subgraph/example1/build
 
   # NOTE: When passed an *URL* as contract path, it is assumed that it points to an already flattened contract file.

--- a/packages/codegen/subgraph-demo.md
+++ b/packages/codegen/subgraph-demo.md
@@ -14,6 +14,12 @@
       * GQL: http://127.0.0.1:8082/graphql
       * RPC: http://127.0.0.1:8081
 
+* For this demo, an [example subgraph](../graph-node/test/subgraph/example1) will be used
+
+  * In [package.json](../graph-node/test/subgraph/example1/package.json), the graph-ts and graph-cli dependencies are replaced by their respective cerc-io forked dependencies
+
+  * This needs to be done for running any subgraph project with watcher-ts
+
 * In watcher-ts [packages/graph-node](../graph-node/), deploy an `Example` contract:
 
   ```bash
@@ -32,19 +38,15 @@
   yarn build:example
   ```
 
+  * This will run `yarn && yarn codegen && yarn build` script in the example subgraph directory
+
 * In [packages/codegen](./), create a `config.yaml` file:
 
   ```yaml
   # Example config.yaml
   # Contracts to watch (required).
   # Can pass empty array ([]) when using subgraphPath.
-  contracts:
-      # Contract name.
-    - name: Example
-      # Contract file path or an url.
-      path: ../graph-node/test/contracts/Example.sol
-      # Contract kind (should match name of dataSource in {subgraphPath}/subgraph.yaml if subgraphPath provided)
-      kind: Example1
+  contracts: []
 
   # Output folder path (logs output using `stdout` if not provided).
   outputFolder: ../test-watcher
@@ -63,6 +65,7 @@
 
   # Path to the subgraph build (optional).
   # Can set empty contracts array when using subgraphPath.
+  # Subgraph WASM files should be compiled using @cerc-io/graph-cli
   subgraphPath: ../graph-node/test/subgraph/example1/build
   ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,7 +271,7 @@
 
 "@cerc-io/assemblyscript@0.19.10-watcher-ts-0.1.2":
   version "0.19.10-watcher-ts-0.1.2"
-  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fassemblyscript/-/0.19.10-watcher-ts-0.1.2/assemblyscript-0.19.10-watcher-ts-0.1.2.tgz"
+  resolved "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fassemblyscript/-/0.19.10-watcher-ts-0.1.2/assemblyscript-0.19.10-watcher-ts-0.1.2.tgz#c6a20eeddca44ddb08994831845c0b172433566b"
   integrity sha512-iovY7xoH5ZMGQZgsK/Wy8175AN2z6I0WUnzEWaxykkAFQUvnErgiw/Y4crkcOb/fDp8gslRfTeEFtR90m1AyPA==
   dependencies:
     asyncify-wasm "^1.2.1"
@@ -4964,7 +4964,7 @@ async@^2.4.0:
 
 asyncify-wasm@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.npmjs.org/asyncify-wasm/-/asyncify-wasm-1.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/asyncify-wasm/-/asyncify-wasm-1.2.1.tgz#a15c0480e858619a4f971e44e6fc05c49015d9e8"
   integrity sha512-ZS7tZ8H8EVbUxAZnkKHvMt9UkYoALue2jwrVl7cnLByjq+1MRrbq7rL5TS+EHQduwkfXD/cNZNa+I0ZyLEBBRQ==
 
 asynckit@^0.4.0:


### PR DESCRIPTION
Part of [Run with sushiswap subgraph](https://www.notion.so/Run-with-sushiswap-v3-subgraph-23ab7c56d790487fa73adcc0b3e513fc?pvs=23)

- Add info in codegen readme about replacing `graph-ts` and `graph-cli` dependencies in subgraph with forked cerc-io packages