### PR TITLE
Use block number for eth_call in `rpc-eth-client`

### DIFF
--- a/packages/codegen/src/data/entities/BlockProgress.yaml
+++ b/packages/codegen/src/data/entities/BlockProgress.yaml
@@ -14,7 +14,7 @@ columns:
     columnType: PrimaryGeneratedColumn
   - name: cid
     pgType: varchar
-    tsType: string
+    tsType: string | null
     columnType: Column
     columnOptions:
       - option: nullable

--- a/packages/codegen/src/data/entities/StateSyncStatus.yaml
+++ b/packages/codegen/src/data/entities/StateSyncStatus.yaml
@@ -12,9 +12,6 @@ columns:
     pgType: integer
     tsType: number
     columnType: Column
-    columnOptions:
-      - option: nullable
-        value: true
 imports:
   - toImport:
       - Entity

--- a/packages/codegen/src/entity.ts
+++ b/packages/codegen/src/entity.ts
@@ -538,6 +538,8 @@ export class Entity {
           option: 'nullable',
           value: 'true'
         });
+
+        columnObject.tsType = `${tsType} | null`;
       }
 
       entityObject.columns.push(columnObject);

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -30,6 +30,9 @@
   # Use -1 for skipping check on block range.
   maxEventsBlockRange = 1000
 
+  # Flag to specify whether RPC endpoint supports block hash as block tag parameter
+  rpcSupportsBlockHashParam = true
+
   # GQL cache settings
   [server.gqlCache]
     enabled = true

--- a/packages/codegen/subgraph-demo.md
+++ b/packages/codegen/subgraph-demo.md
@@ -116,7 +116,15 @@
   yarn && yarn build
   ```
 
-* In `packages/test-watcher`, run the job-runner:
+* In `packages/test-watcher`, run fill for the subgraph start block:
+
+  ```bash
+  yarn fill --start-block 10 --end-block 10
+  ```
+
+  * Subgraph start block is the lowest `startBlock` in example [subgraph.yaml](../graph-node/test/subgraph/example1/subgraph.yaml)
+
+* Run the job-runner:
 
   ```bash
   yarn job-runner

--- a/packages/graph-node/src/call-handler.test.ts
+++ b/packages/graph-node/src/call-handler.test.ts
@@ -71,6 +71,7 @@ xdescribe('call handler in mapping code', () => {
       indexer,
       provider,
       {
+        rpcSupportsBlockHashParam: true,
         block: dummyEventData.block,
         contractAddress: dummyGraphData.dataSource.address
       },

--- a/packages/graph-node/src/crypto.test.ts
+++ b/packages/graph-node/src/crypto.test.ts
@@ -33,7 +33,7 @@ describe('crypto host api', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       filePath,
       dummyGraphData
     );

--- a/packages/graph-node/src/eden.test.ts
+++ b/packages/graph-node/src/eden.test.ts
@@ -90,6 +90,7 @@ xdescribe('eden wasm loader tests', async () => {
         indexer,
         provider,
         {
+          rpcSupportsBlockHashParam: true,
           block: dummyEventData.block,
           contractAddress
         },
@@ -210,6 +211,7 @@ xdescribe('eden wasm loader tests', async () => {
         indexer,
         provider,
         {
+          rpcSupportsBlockHashParam: true,
           block: dummyEventData.block,
           contractAddress
         },
@@ -328,6 +330,7 @@ xdescribe('eden wasm loader tests', async () => {
         indexer,
         provider,
         {
+          rpcSupportsBlockHashParam: true,
           block: dummyEventData.block,
           contractAddress
         },

--- a/packages/graph-node/src/eth-abi.test.ts
+++ b/packages/graph-node/src/eth-abi.test.ts
@@ -33,7 +33,7 @@ describe('ethereum ABI encode decode', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       filePath,
       dummyGraphData
     );

--- a/packages/graph-node/src/eth-call.test.ts
+++ b/packages/graph-node/src/eth-call.test.ts
@@ -51,6 +51,7 @@ xdescribe('eth-call wasm tests', () => {
       indexer,
       provider,
       {
+        rpcSupportsBlockHashParam: true,
         block: dummyEventData.block,
         contractAddress
       },

--- a/packages/graph-node/src/json.test.ts
+++ b/packages/graph-node/src/json.test.ts
@@ -31,7 +31,7 @@ describe('json host api', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       filePath,
       dummyGraphData
     );

--- a/packages/graph-node/src/loader.test.ts
+++ b/packages/graph-node/src/loader.test.ts
@@ -35,7 +35,7 @@ describe('wasm loader tests', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       filePath,
       dummyGraphData
     );
@@ -113,7 +113,7 @@ describe('wasm loader tests', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       module,
       dummyGraphData
     );

--- a/packages/graph-node/src/numbers.test.ts
+++ b/packages/graph-node/src/numbers.test.ts
@@ -44,7 +44,7 @@ describe('numbers wasm tests', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       filePath,
       dummyGraphData
     );

--- a/packages/graph-node/src/storage-call.test.ts
+++ b/packages/graph-node/src/storage-call.test.ts
@@ -52,6 +52,7 @@ xdescribe('storage-call wasm tests', () => {
       indexer,
       provider,
       {
+        rpcSupportsBlockHashParam: true,
         block: dummyEventData.block,
         contractAddress
       },

--- a/packages/graph-node/src/type-conversion.test.ts
+++ b/packages/graph-node/src/type-conversion.test.ts
@@ -33,7 +33,7 @@ describe('typeConversion wasm tests', () => {
       db,
       indexer,
       provider,
-      {},
+      { rpcSupportsBlockHashParam: true },
       filePath,
       dummyGraphData
     );

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -52,7 +52,7 @@ export class GraphWatcher {
   _dataSourceMap: { [key: string]: DataSource } = {};
   _transactionsMap: Map<string, Transaction> = new Map();
 
-  _context: Context = {};
+  _context: Context;
 
   constructor (database: GraphDatabase, ethClient: EthClient, ethProvider: providers.BaseProvider, serverConfig: ServerConfig) {
     this._database = database;
@@ -60,6 +60,10 @@ export class GraphWatcher {
     this._ethProvider = ethProvider;
     this._subgraphPath = serverConfig.subgraphPath;
     this._wasmRestartBlocksInterval = serverConfig.wasmRestartBlocksInterval;
+
+    this._context = {
+      rpcSupportsBlockHashParam: Boolean(serverConfig.rpcSupportsBlockHashParam)
+    };
   }
 
   async init () {

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -166,7 +166,8 @@ export class EthClient implements EthClientInterface {
       Extra: rawBlock.extraData,
       MixDigest: rawBlock.mixHash,
       Nonce: BigInt(rawBlock.nonce),
-      BaseFee: BigInt(rawBlock.baseFeePerGas)
+      // TODO: Fix optional values
+      BaseFee: rawBlock.baseFeePerGas ?? BigInt(rawBlock.baseFeePerGas)
     };
 
     const rlpData = encodeHeader(header);

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -166,7 +166,6 @@ export class EthClient implements EthClientInterface {
       Extra: rawBlock.extraData,
       MixDigest: rawBlock.mixHash,
       Nonce: BigInt(rawBlock.nonce),
-      // TODO: Fix optional values
       BaseFee: rawBlock.baseFeePerGas ?? BigInt(rawBlock.baseFeePerGas)
     };
 

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -221,6 +221,7 @@ export interface ServerConfig {
 
   p2p: P2PConfig;
 
+  // TODO: Move flag to config upstream.ethServer
   // Flag to specify whether RPC endpoint supports block hash as block tag parameter
   // https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block
   rpcSupportsBlockHashParam: boolean;

--- a/packages/util/src/graph/state-utils.ts
+++ b/packages/util/src/graph/state-utils.ts
@@ -151,7 +151,12 @@ export const getContractEntitiesMap = (dataSources: any[]): Map<string, string[]
   // Populate contractEntitiesMap using data sources from subgraph
   dataSources.forEach((dataSource: any) => {
     const { source: { address: contractAddress }, mapping: { entities } } = dataSource;
-    contractEntitiesMap.set(ethers.utils.getAddress(contractAddress), entities as string[]);
+
+    // TODO: Handle template data source
+    // TODO: Avoid mapping subgraph entities to contract address in watcher state
+    if (contractAddress) {
+      contractEntitiesMap.set(ethers.utils.getAddress(contractAddress), entities as string[]);
+    }
   });
 
   return contractEntitiesMap;

--- a/packages/util/src/graph/utils.ts
+++ b/packages/util/src/graph/utils.ts
@@ -550,7 +550,7 @@ export const toEntityValue = async (instanceExports: any, entityInstance: any, d
   // Check if the entity property is nullable.
   // No need to set the property if the value is null as well.
   if (isNullable && value === null) {
-    return;
+    return value;
   }
 
   const entityValue = await formatEntityValue(instanceExports, subgraphValue, type, value, isArray);

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -52,7 +52,7 @@ export interface StateStatus {
 
 export type ResultState = {
   block: {
-    cid: string;
+    cid: string | null;
     hash: string;
     number: number;
     timestamp: number;
@@ -66,7 +66,7 @@ export type ResultState = {
 
 export type ResultEvent = {
   block: {
-    cid: string;
+    cid: string | null;
     hash: string;
     number: number;
     timestamp: number;

--- a/packages/util/src/state-helper.ts
+++ b/packages/util/src/state-helper.ts
@@ -20,7 +20,7 @@ export interface StateDataMeta {
   },
   ethBlock: {
     cid: {
-      '/': string
+      '/': string | null
     },
     num: number
   }

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -19,7 +19,7 @@ export enum StateKind {
 
 export interface BlockProgressInterface {
   id: number;
-  cid: string;
+  cid: string | null;
   blockHash: string;
   parentHash: string;
   blockNumber: number;


### PR DESCRIPTION
Part of [Run with sushiswap subgraph](https://www.notion.so/Run-with-sushiswap-v3-subgraph-23ab7c56d790487fa73adcc0b3e513fc?pvs=23) and [Template support](https://www.notion.so/Template-support-874b8c562e6042ddb7bf113e54baad28?pvs=23)

- Handle contract entities map creation for template data source
- Use block number for `eth_call` in `rpc-eth-client` with `rpcSupportsBlockHashParam` flag 
- Use null in TypeScript for nullable columns
- Fix optional baseFeePerGas in rpc-eth-client