### PR TITLE
Skip checking of events order while processing due to incorrect `logIndex` in FEVM

### DIFF
--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -67,6 +67,9 @@
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
 
+    # Flag to specify if rpc-eth-client should be used from RPC endpoint instead of ipld-eth-client (ipld-eth-server GQL client)
+    rpcClient = false
+
   [upstream.cache]
     name = "requests"
     enabled = false

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -299,10 +299,14 @@ export const processBatchEvents = async (indexer: IndexerInterface, block: Block
 
           assert(indexer.parseEventNameAndArgs);
           assert(typeof watchedContract !== 'boolean');
-          const { eventName, eventInfo } = indexer.parseEventNameAndArgs(watchedContract.kind, logObj);
+          const { eventName, eventInfo, eventSignature } = indexer.parseEventNameAndArgs(watchedContract.kind, logObj);
 
           event.eventName = eventName;
           event.eventInfo = JSONbigNative.stringify(eventInfo);
+          event.extraInfo = JSONbigNative.stringify({
+            ...logObj,
+            eventSignature
+          });
           event = await indexer.saveEventEntity(event);
         }
 

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -10,7 +10,8 @@ import {
   QUEUE_BLOCK_CHECKPOINT,
   JOB_KIND_PRUNE,
   JOB_KIND_INDEX,
-  UNKNOWN_EVENT_NAME
+  UNKNOWN_EVENT_NAME,
+  NULL_BLOCK_ERROR
 } from './constants';
 import { JobQueue } from './job-queue';
 import { BlockProgressInterface, IndexerInterface, EventInterface } from './types';
@@ -106,7 +107,7 @@ export const fetchBlocksAtHeight = async (
       }
     } catch (err: any) {
       // Handle null block error in case of Lotus EVM
-      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === 'requested epoch was a null round')) {
+      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === NULL_BLOCK_ERROR)) {
         throw err;
       }
 
@@ -197,7 +198,7 @@ export const _fetchBatchBlocks = async (
       //  Handle null block error in case of Lotus EVM
       //  Otherwise, rethrow error
       const err = result.reason;
-      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === 'requested epoch was a null round')) {
+      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === NULL_BLOCK_ERROR)) {
         throw err;
       }
 

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -2,6 +2,7 @@ import debug from 'debug';
 import assert from 'assert';
 import { DeepPartial } from 'typeorm';
 import { errors } from 'ethers';
+import JSONbig from 'json-bigint';
 
 import {
   QUEUE_BLOCK_PROCESSING,
@@ -20,6 +21,7 @@ import { JobQueueConfig } from './config';
 const DEFAULT_EVENTS_IN_BATCH = 50;
 
 const log = debug('vulcanize:common');
+const JSONbigNative = JSONbig({ useNativeBigInt: true });
 
 export interface PrefetchedBlock {
   block: BlockProgressInterface;
@@ -300,7 +302,7 @@ export const processBatchEvents = async (indexer: IndexerInterface, block: Block
           const { eventName, eventInfo } = indexer.parseEventNameAndArgs(watchedContract.kind, logObj);
 
           event.eventName = eventName;
-          event.eventInfo = JSON.stringify(eventInfo);
+          event.eventInfo = JSONbigNative.stringify(eventInfo);
           event = await indexer.saveEventEntity(event);
         }
 

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -29,3 +29,5 @@ export const DEFAULT_PREFETCH_BATCH_SIZE = 10;
 export const DEFAULT_MAX_GQL_CACHE_SIZE = Math.pow(2, 20) * 8; // 8 MB
 
 export const SUPPORTED_PAID_RPC_METHODS = ['eth_getBlockByHash', 'eth_getStorageAt', 'eth_getBlockByNumber'];
+
+export const NULL_BLOCK_ERROR = 'requested epoch was a null round';

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -190,10 +190,6 @@ export class Database {
 
   async updateBlockProgress (repo: Repository<BlockProgressInterface>, block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface> {
     if (!block.isComplete) {
-      if (lastProcessedEventIndex <= block.lastProcessedEventIndex) {
-        throw new Error(`Events processed out of order ${block.blockHash}, was ${block.lastProcessedEventIndex}, got ${lastProcessedEventIndex}`);
-      }
-
       block.lastProcessedEventIndex = lastProcessedEventIndex;
       block.numProcessedEvents++;
     }


### PR DESCRIPTION
Part of [Run with sushiswap subgraph](https://www.notion.so/Run-with-sushiswap-v3-subgraph-23ab7c56d790487fa73adcc0b3e513fc?pvs=23)

- FEVM returns incorrect `logIndex` in `eth_getLogs` response
  - Skip check of order using `logIndex` as unprocessed block is removed on restarts and reprocessed from start
  - For batch events processing, use pagination instead of using `block.lastProcessedIndex` (set using `logIndex`)
- Use json-bigint stringify in job-runner `processBatchEvents` method
- Set event signature in events processing for contracts watched after subgraph template create
- Handle null block in async caching of block size