### PR TITLE
Avoid updating StateSyncStatus table when `enableState` flag is set to false

### DIFF
--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -493,7 +493,11 @@ export class Indexer implements IndexerInterface {
     return this._db.getStateSyncStatus();
   }
 
-  async updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatus> {
+  async updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatus | undefined> {
+    if (!this._serverConfig.enableState) {
+      return;
+    }
+    
     const dbTx = await this._db.createTransactionRunner();
     let res;
 

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -8,7 +8,7 @@ import debug from 'debug';
 {{#if queries}}
 import JSONbig from 'json-bigint';
 {{/if}}
-import { ethers } from 'ethers';
+import { ethers, constants } from 'ethers';
 {{#if (subgraphPath)}}
 import { SelectionNode } from 'graphql';
 {{/if}}
@@ -527,9 +527,13 @@ export class Indexer implements IndexerInterface {
     return res;
   }
 
-  async getLatestCanonicalBlock (): Promise<BlockProgress> {
+  async getLatestCanonicalBlock (): Promise<BlockProgress | undefined> {
     const syncStatus = await this.getSyncStatus();
     assert(syncStatus);
+
+    if (syncStatus.latestCanonicalBlockHash === constants.HashZero) {
+      return;
+    }
 
     const latestCanonicalBlock = await this.getBlockProgress(syncStatus.latestCanonicalBlockHash);
     assert(latestCanonicalBlock);

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -189,8 +189,8 @@ export class Indexer implements IndexerInterface {
     return undefined;
   }
 
-  async updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface> {
-    return {} as StateSyncStatusInterface;
+  async updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface | undefined> {
+    return undefined;
   }
 
   async updateStateSyncStatusCheckpointBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface> {

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -197,8 +197,8 @@ export class Indexer implements IndexerInterface {
     return {} as StateSyncStatusInterface;
   }
 
-  async getLatestCanonicalBlock (): Promise<BlockProgressInterface> {
-    return {} as BlockProgressInterface;
+  async getLatestCanonicalBlock (): Promise<BlockProgressInterface | undefined> {
+    return undefined;
   }
 
   isWatchedContract (address : string): ContractInterface | undefined {

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -321,7 +321,7 @@ export const processEvents = async (indexer: IndexerInterface, block: BlockProgr
         // We might not have parsed this event yet. This can happen if the contract was added
         // as a result of a previous event in the same block.
         if (event.eventName === UNKNOWN_EVENT_NAME) {
-          const logObj = JSON.parse(event.extraInfo);
+          const logObj = JSONbigNative.parse(event.extraInfo);
 
           assert(indexer.parseEventNameAndArgs);
           assert(typeof watchedContract !== 'boolean');

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -481,12 +481,11 @@ export const createPruningJob = async (jobQueue: JobQueue, latestCanonicalBlockN
  * @param blockHash
  * @param blockNumber
  */
-export const createHooksJob = async (jobQueue: JobQueue, blockHash: string, blockNumber: number): Promise<void> => {
+export const createHooksJob = async (jobQueue: JobQueue, blockHash: string): Promise<void> => {
   await jobQueue.pushJob(
     QUEUE_HOOKS,
     {
-      blockHash,
-      blockNumber
+      blockHash
     }
   );
 };

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -422,7 +422,7 @@ export const processEventsInSubgraphOrder = async (indexer: IndexerInterface, bl
       // We might not have parsed this event yet. This can happen if the contract was added
       // as a result of a previous event in the same block.
       if (event.eventName === UNKNOWN_EVENT_NAME) {
-        const logObj = JSON.parse(event.extraInfo);
+        const logObj = JSONbigNative.parse(event.extraInfo);
 
         assert(indexer.parseEventNameAndArgs);
         assert(typeof watchedContract !== 'boolean');

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -91,7 +91,7 @@ export interface IndexerInterface {
   getStateSyncStatus (): Promise<StateSyncStatusInterface | undefined>
   getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<any>
   getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgressInterface[]>
-  getLatestCanonicalBlock (): Promise<BlockProgressInterface>
+  getLatestCanonicalBlock (): Promise<BlockProgressInterface | undefined>
   getLatestStateIndexedBlock (): Promise<BlockProgressInterface>
   getBlockEvents (blockHash: string, where: Where, queryOptions: QueryOptions): Promise<Array<EventInterface>>
   getAncestorAtDepth (blockHash: string, depth: number): Promise<string>

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -102,7 +102,7 @@ export interface IndexerInterface {
   updateSyncStatusChainHead (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateSyncStatusIndexedBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateSyncStatusCanonicalBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
-  updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface>
+  updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface | undefined>
   updateStateSyncStatusCheckpointBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface>
   markBlocksAsPruned (blocks: BlockProgressInterface[]): Promise<void>
   saveEventEntity (dbEvent: EventInterface): Promise<EventInterface>


### PR DESCRIPTION
Part of [Run with sushiswap subgraph](https://www.notion.so/Run-with-sushiswap-v3-subgraph-23ab7c56d790487fa73adcc0b3e513fc?pvs=23)

- Handle zero hash canonical block in case of FEVM null block
- Avoid updating StateSyncStatus table when `enableState` flag is false