### PR TITLE
Add new job queue for historical blocks processing

### DIFF
--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -253,6 +253,12 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.updateSyncStatusChainHead(repo, blockHash, blockNumber, force);
   }
 
+  async forceUpdateSyncStatus (queryRunner: QueryRunner, blockHash: string, blockNumber: number): Promise<SyncStatus> {
+    const repo = queryRunner.manager.getRepository(SyncStatus);
+
+    return this._baseDatabase.forceUpdateSyncStatus(repo, blockHash, blockNumber);
+  }
+
   async getSyncStatus (queryRunner: QueryRunner): Promise<SyncStatus | undefined> {
     const repo = queryRunner.manager.getRepository(SyncStatus);
 
@@ -269,6 +275,12 @@ export class Database implements DatabaseInterface {
     const repo = this._conn.getRepository(BlockProgress);
 
     return this._baseDatabase.getBlocksAtHeight(repo, height, isPruned);
+  }
+
+  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
+    const repo = this._conn.getRepository(BlockProgress);
+
+    return this._baseDatabase.getLatestProcessedBlockProgress(repo, isPruned);
   }
 
   async markBlocksAsPruned (queryRunner: QueryRunner, blocks: BlockProgress[]): Promise<void> {

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -509,7 +509,7 @@ export class Indexer implements IndexerInterface {
     if (!this._serverConfig.enableState) {
       return;
     }
-    
+
     const dbTx = await this._db.createTransactionRunner();
     let res;
 
@@ -637,6 +637,10 @@ export class Indexer implements IndexerInterface {
     return syncStatus;
   }
 
+  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatus> {
+    return this._baseIndexer.forceUpdateSyncStatus(blockHash, blockNumber);
+  }
+
   async getEvent (id: string): Promise<Event | undefined> {
     return this._baseIndexer.getEvent(id);
   }
@@ -651,6 +655,10 @@ export class Indexer implements IndexerInterface {
 
   async getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgress[]> {
     return this._baseIndexer.getBlocksAtHeight(height, isPruned);
+  }
+
+  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
+    return this._db.getLatestProcessedBlockProgress(isPruned);
   }
 
   async fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgress>[]): Promise<{ blockProgress: BlockProgress, events: DeepPartial<Event>[] }[]> {

--- a/packages/codegen/src/templates/job-runner-template.handlebars
+++ b/packages/codegen/src/templates/job-runner-template.handlebars
@@ -34,6 +34,7 @@ export const main = async (): Promise<any> => {
 
   await jobRunnerCmd.exec(async (jobRunner: JobRunner): Promise<void> => {
     await jobRunner.subscribeBlockProcessingQueue();
+    await jobRunner.subscribeHistoricalProcessingQueue();
     await jobRunner.subscribeEventProcessingQueue();
     await jobRunner.subscribeBlockCheckpointQueue();
     await jobRunner.subscribeHooksQueue();

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -93,6 +93,12 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
+  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgressInterface | undefined> {
+    assert(isPruned);
+
+    return undefined;
+  }
+
   async getBlockEvents (blockHash: string): Promise<Array<EventInterface>> {
     assert(blockHash);
 
@@ -146,6 +152,13 @@ export class Indexer implements IndexerInterface {
     assert(blockNumber);
     assert(blockHash);
     assert(force);
+
+    return {} as SyncStatusInterface;
+  }
+
+  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatusInterface> {
+    assert(blockNumber);
+    assert(blockHash);
 
     return {} as SyncStatusInterface;
   }

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -182,6 +182,9 @@ export const _fetchBatchBlocks = async (
   while (true) {
     console.time('time:common#fetchBatchBlocks-getBlocks');
 
+    // TODO: Fetch logs by filter before fetching blocks
+    // TODO: Fetch only blocks needed for returned logs
+    // TODO: Save blocks and logs to DB
     const blockPromises = blockNumbers.map(async blockNumber => indexer.getBlocks({ blockNumber }));
     const settledResults = await Promise.allSettled(blockPromises);
 

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -129,7 +129,7 @@ export const fetchBlocksAtHeight = async (
       cid,
       blockHash,
       parentHash,
-      blockTimestamp: timestamp
+      blockTimestamp: Number(timestamp)
     });
   }
 
@@ -241,7 +241,7 @@ export const _fetchBatchBlocks = async (
   }
 
   blocks.forEach(block => {
-    block.blockTimestamp = block.timestamp;
+    block.blockTimestamp = Number(block.timestamp);
     block.blockNumber = Number(block.blockNumber);
   });
 
@@ -268,7 +268,7 @@ export const processBatchEvents = async (indexer: IndexerInterface, block: Block
 
   if (indexer.processBlockAfterEvents) {
     if (!dbBlock.isComplete) {
-      await indexer.processBlockAfterEvents(block.blockHash, block.blockNumber);
+      await indexer.processBlockAfterEvents(dbBlock.blockHash, dbBlock.blockNumber);
     }
   }
 

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -6,6 +6,7 @@ export const MAX_REORG_DEPTH = 16;
 export const DIFF_MERGE_BATCH_SIZE = 10000;
 
 export const QUEUE_BLOCK_PROCESSING = 'block-processing';
+export const QUEUE_HISTORICAL_PROCESSING = 'historical-processing';
 export const QUEUE_EVENT_PROCESSING = 'event-processing';
 export const QUEUE_CHAIN_PRUNING = 'chain-pruning';
 export const QUEUE_BLOCK_CHECKPOINT = 'block-checkpoint';

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -45,6 +45,8 @@ export class EventWatcher {
   async start (): Promise<void> {
     await this.initBlockProcessingOnCompleteHandler();
     await this.initEventProcessingOnCompleteHandler();
+    // TODO: Add JOB QUEUE complete handler for new historical processing job
+    // TODO: Start realtime processing once historical processing end block is reached
 
     this.startBlockProcessing();
 
@@ -75,6 +77,8 @@ export class EventWatcher {
       startBlockNumber = syncStatus.chainHeadBlockNumber + 1;
     }
 
+    // TODO: Check if processing is for historical or latest block by fetching latest block first
+    // TODO: For historical processing push to a new job queue instead of starting realtime sync
     await processBlockByNumber(this._jobQueue, startBlockNumber);
 
     // Creating an AsyncIterable from AsyncIterator to iterate over the values.

--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -130,7 +130,13 @@ const prefetchBlocks = async (
       const blockProgress = await indexer.getBlockProgress(blockHash);
 
       if (!blockProgress) {
-        await indexer.saveBlockAndFetchEvents({ cid, blockHash, blockNumber, parentHash, blockTimestamp: timestamp });
+        await indexer.saveBlockAndFetchEvents({
+          cid,
+          blockHash,
+          blockNumber: Number(blockNumber),
+          parentHash,
+          blockTimestamp: Number(timestamp)
+        });
       }
     });
 

--- a/packages/util/src/index-block.ts
+++ b/packages/util/src/index-block.ts
@@ -22,7 +22,8 @@ export const indexBlock = async (
     const blocks = await indexer.getBlocks({ blockNumber: argv.block });
 
     blockProgressEntities = blocks.map((block: any): Partial<BlockProgressInterface> => {
-      block.blockTimestamp = block.timestamp;
+      block.blockTimestamp = Number(block.timestamp);
+      block.blockNumber = Number(block.blockNumber);
 
       return block;
     });

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -194,6 +194,23 @@ export class Indexer {
     return res;
   }
 
+  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatusInterface> {
+    const dbTx = await this._db.createTransactionRunner();
+    let res;
+
+    try {
+      res = await this._db.forceUpdateSyncStatus(dbTx, blockHash, blockNumber);
+      await dbTx.commitTransaction();
+    } catch (error) {
+      await dbTx.rollbackTransaction();
+      throw error;
+    } finally {
+      await dbTx.release();
+    }
+
+    return res;
+  }
+
   async getBlocks (blockFilter: { blockNumber?: number, blockHash?: string }): Promise<any> {
     assert(blockFilter.blockHash || blockFilter.blockNumber);
     const result = await this._ethClient.getBlocks(blockFilter);

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -114,7 +114,7 @@ export class JobQueue {
         teamSize: JOBS_PER_INTERVAL,
         teamConcurrency: 1
       },
-      async (job: any) => {
+      async (job: PgBoss.JobWithDoneCallback<any, any>) => {
         try {
           const { id, data: { failed, createdOn } } = job;
           log(`Job onComplete for queue ${queue} job ${id} created ${createdOn} success ${!failed}`);

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -13,7 +13,7 @@ interface Config {
   maxCompletionLag: number
 }
 
-type JobCallback = (job: any) => Promise<void>;
+type JobCallback = (job: PgBoss.JobWithDoneCallback<any, any>) => Promise<void>;
 
 const JOBS_PER_INTERVAL = 5;
 
@@ -93,7 +93,7 @@ export class JobQueue {
         teamSize: JOBS_PER_INTERVAL,
         teamConcurrency: 1
       },
-      async (job: any) => {
+      async (job) => {
         try {
           log(`Processing queue ${queue} job ${job.id}...`);
           await callback(job);
@@ -128,7 +128,7 @@ export class JobQueue {
     );
   }
 
-  async markComplete (job: any): Promise<void> {
+  async markComplete (job: PgBoss.Job): Promise<void> {
     this._boss.complete(job.id);
   }
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -396,8 +396,9 @@ export class JobRunner {
     console.timeEnd('time:job-runner#_indexBlock-get-block-progress-entities');
 
     // Check if parent block has been processed yet, if not, push a high priority job to process that first and abort.
-    // However, don't go beyond the `latestCanonicalBlockHash` from SyncStatus as we have to assume the reorg can't be that deep.
-    if (blockHash !== syncStatus.latestCanonicalBlockHash) {
+    // However, don't go beyond the `latestCanonicalBlockNumber` from SyncStatus as we have to assume the reorg can't be that deep.
+    // latestCanonicalBlockNumber is used to handle null blocks in case of FEVM.
+    if (blockNumber > syncStatus.latestCanonicalBlockNumber) {
       // Create a higher priority job to index parent block and then abort.
       // We don't have to worry about aborting as this job will get retried later.
       const newPriority = (priority || 0) + 1;
@@ -418,9 +419,9 @@ export class JobRunner {
           kind: JOB_KIND_INDEX,
           cid: parentCid,
           blockHash: parentHash,
-          blockNumber: parentBlockNumber,
+          blockNumber: Number(parentBlockNumber),
           parentHash: grandparentHash,
-          timestamp: parentTimestamp,
+          timestamp: Number(parentTimestamp),
           priority: newPriority
         }, { priority: newPriority });
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -75,6 +75,9 @@ export class JobRunner {
     });
   }
 
+  // TODO: Add a new JOB QUEUE for processing historical blocks
+  // TODO: New job will fetch filtered logs and blocks in batches
+
   async processBlock (job: any): Promise<void> {
     const { data: { kind } } = job;
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -39,7 +39,7 @@ const log = debug('vulcanize:job-runner');
 // Wait time for retrying events processing on error (in ms)
 const EVENTS_PROCESSING_RETRY_WAIT = 2000;
 
-interface HistoricalJobData {
+export interface HistoricalJobData {
   blockNumber: number;
 }
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -39,6 +39,9 @@ const log = debug('vulcanize:job-runner');
 // Wait time for retrying events processing on error (in ms)
 const EVENTS_PROCESSING_RETRY_WAIT = 2000;
 
+// TODO: Get batch size from config
+export const HISTORICAL_BLOCKS_BATCH_SIZE = 100;
+
 export interface HistoricalJobData {
   blockNumber: number;
 }
@@ -145,9 +148,10 @@ export class JobRunner {
   }
 
   async processHistoricalBlocks (job: PgBoss.JobWithDoneCallback<HistoricalJobData, HistoricalJobData>): Promise<void> {
-    const { data: { blockNumber } } = job;
+    const { data: { blockNumber: startBlock } } = job;
+    const endBlock = startBlock + HISTORICAL_BLOCKS_BATCH_SIZE;
 
-    log(`Processing historical blocks after block ${blockNumber}`);
+    log(`Processing historical blocks from ${startBlock} to ${endBlock}`);
     // TODO: Use method from common.ts to fetch and save filtered logs and blocks
     const blocks: BlockProgressInterface[] = [];
 

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -91,6 +91,7 @@ export interface IndexerInterface {
   getStateSyncStatus (): Promise<StateSyncStatusInterface | undefined>
   getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<any>
   getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgressInterface[]>
+  getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgressInterface | undefined>
   getLatestCanonicalBlock (): Promise<BlockProgressInterface | undefined>
   getLatestStateIndexedBlock (): Promise<BlockProgressInterface>
   getBlockEvents (blockHash: string, where: Where, queryOptions: QueryOptions): Promise<Array<EventInterface>>
@@ -102,6 +103,7 @@ export interface IndexerInterface {
   updateSyncStatusChainHead (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateSyncStatusIndexedBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateSyncStatusCanonicalBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
+  forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatusInterface>
   updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface | undefined>
   updateStateSyncStatusCheckpointBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface>
   markBlocksAsPruned (blocks: BlockProgressInterface[]): Promise<void>
@@ -164,6 +166,7 @@ export interface DatabaseInterface {
   updateSyncStatusIndexedBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
   updateSyncStatusChainHead (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
   updateSyncStatusCanonicalBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
+  forceUpdateSyncStatus (queryRunner: QueryRunner, blockHash: string, blockNumber: number): Promise<SyncStatusInterface>;
   saveEvents (queryRunner: QueryRunner, events: DeepPartial<EventInterface>[]): Promise<void>;
   saveBlockWithEvents (queryRunner: QueryRunner, block: DeepPartial<BlockProgressInterface>, events: DeepPartial<EventInterface>[]): Promise<BlockProgressInterface>;
   saveEventEntity (queryRunner: QueryRunner, entity: EventInterface): Promise<EventInterface>;


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Add job queue for fetching filtered logs in a block range
- Fetch latest block in chain and start historical block processing
- Start realtime block processing after historical processing completes
- TODOs to be fulfilled in follow on PRs:
  - Fix async block size data caching running for missing blocks in historical processing
  - Fetch logs by filter first and then fetch only required blocks
  - Get block range for fetching logs in historical processing from config
  - Remove entities for a block on retrying events processing in error handler