### PR TITLE
Generate plural GQL query schema for subgraph entities

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -28,6 +28,7 @@
     "gql-generator": "https://github.com/vulcanize/gql-generator.git",
     "graphql": "^15.5.0",
     "graphql-compose": "^9.0.3",
+    "pluralize": "^8.0.0",
     "handlebars": "^4.7.7",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.21",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@openzeppelin/contracts": "^4.3.2",
     "@types/js-yaml": "^4.0.3",
+    "@types/pluralize": "^0.0.29",
     "@types/lodash": "^4.14.168",
     "@types/node": "^16.9.0",
     "@types/yargs": "^17.0.0",

--- a/packages/codegen/src/resolvers.ts
+++ b/packages/codegen/src/resolvers.ts
@@ -68,6 +68,7 @@ export class Resolvers {
         queryName
       };
 
+      // TODO: Generate plural query resolvers
       this._subgraphQueries.push(queryObject);
     }
   }

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -197,7 +197,6 @@ export class Schema {
         }
       };
 
-      // TODO: Add query type filter (subgraphType_filter) (input)
       // Add plural query
 
       // Create the subgraphType_orderBy enum type
@@ -219,8 +218,9 @@ export class Schema {
         // Get type composer object for return type from the schema composer.
         type: this._composer.getAnyTC(subgraphType).NonNull.List.NonNull,
         args: {
-          // where: Staker_filter,
           block: BlockHeight,
+          // TODO: Create input type for where clause
+          // where: subgraphType_filter,
           orderBy: subgraphTypeOrderByEnum,
           orderDirection: OrderDirection,
           first: { type: GraphQLInt, defaultValue: 100 },

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -83,6 +83,7 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
   eventsInBatch = 50
+  subgraphEventsOrder = true
   blockDelayInMilliSecs = 2000
   prefetchBlocksInMem = true
   prefetchBlockCount = 10

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -829,12 +829,10 @@ export class Database {
 
         whereClause += `${OPERATOR_MAP[operator]} `;
 
+        value = this._transformBigIntValues(value);
         if (operator === 'in') {
           whereClause += '(:...';
         } else {
-          // Convert to string type value as bigint type throws error in query.
-          value = value.toString();
-
           whereClause += ':';
         }
 
@@ -899,5 +897,21 @@ export class Database {
       .count();
 
     eventCount.set(res);
+  }
+
+  _transformBigIntValues (value: any): any {
+    if (Array.isArray(value)) {
+      if (value.length > 0 && typeof value[0] === 'bigint') {
+        return value.map(val => {
+          return val.toString();
+        });
+      }
+
+      return value;
+    }
+
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
   }
 }


### PR DESCRIPTION
Part of [Implement GQL API same as graph-node](https://www.notion.so/Implement-GQL-API-same-as-graph-node-241ea9811a244cb8a62f3ae5e69a82d6?pvs=23

- Generate plural GQL queries with following args:
  - `block` (for time travel queries)
  - `orderBy` and `orderDirection` (for sorting)
  - `first` and `skip` (for paging)
- To be handled in a follow on PR:
  - `where` arg for filtering
  - Resolvers for plural queries