### PR TITLE
Implement fetch and save of filtered event logs and required blocks

### DIFF
--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -128,12 +128,13 @@ export class BaseCmd {
 
   async initEventWatcher (): Promise<void> {
     assert(this._clients?.ethClient);
+    assert(this._config);
     assert(this._indexer);
     assert(this._jobQueue);
 
     // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
     // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
     const pubsub = new PubSub();
-    this._eventWatcher = new EventWatcher(this._clients.ethClient, this._indexer, pubsub, this._jobQueue);
+    this._eventWatcher = new EventWatcher(this._config.server, this._clients.ethClient, this._indexer, pubsub, this._jobQueue);
   }
 }

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -29,6 +29,11 @@
   # Boolean to filter logs by topics.
   filterLogsByTopics = false
 
+  # Boolean to switch between modes of processing events when starting the server.
+  # Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
+  # Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
+  useBlockRanges = true
+
   # Max block range for which to return events in eventsInRange GQL query.
   # Use -1 for skipping check on block range.
   maxEventsBlockRange = 1000

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -277,12 +277,6 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getBlocksAtHeight(repo, height, isPruned);
   }
 
-  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
-    const repo = this._conn.getRepository(BlockProgress);
-
-    return this._baseDatabase.getLatestProcessedBlockProgress(repo, isPruned);
-  }
-
   async markBlocksAsPruned (queryRunner: QueryRunner, blocks: BlockProgress[]): Promise<void> {
     const repo = queryRunner.manager.getRepository(BlockProgress);
 

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -657,10 +657,6 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getBlocksAtHeight(height, isPruned);
   }
 
-  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
-    return this._db.getLatestProcessedBlockProgress(isPruned);
-  }
-
   async fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgress>[]): Promise<{ blockProgress: BlockProgress, events: DeepPartial<Event>[] }[]> {
     return this._baseIndexer.fetchEventsAndSaveBlocks(blocks, this._eventSignaturesMap, this.parseEventNameAndArgs.bind(this));
   }

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -93,12 +93,6 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
-  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgressInterface | undefined> {
-    assert(isPruned);
-
-    return undefined;
-  }
-
   async getBlockEvents (blockHash: string): Promise<Array<EventInterface>> {
     assert(blockHash);
 

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -112,6 +112,13 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
+  async fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]> {
+    assert(startBlock);
+    assert(endBlock);
+
+    return [];
+  }
+
   async saveBlockAndFetchEvents (block: BlockProgressInterface): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]> {
     return [block, []];
   }

--- a/packages/util/src/block-size-cache.ts
+++ b/packages/util/src/block-size-cache.ts
@@ -41,7 +41,7 @@ const cacheBlockSizesAsync = async (provider: providers.JsonRpcProvider, blockNu
   }
 
   if (endBlockHeight > blockSizeMapLatestHeight) {
-    const startBlockHeight = blockSizeMapLatestHeight + 1;
+    const startBlockHeight = Math.max(blockNumber, blockSizeMapLatestHeight + 1);
     blockSizeMapLatestHeight = endBlockHeight;
 
     // Start prefetching blocks after latest height in blockSizeMap.

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -205,6 +205,11 @@ export interface ServerConfig {
   maxEventsBlockRange: number;
   clearEntitiesCacheInterval: number;
 
+  // Boolean to switch between modes of processing events when starting the server.
+  // Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
+  // Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
+  useBlockRanges: boolean;
+
   // Boolean to skip updating entity fields required in state creation and not required in the frontend.
   skipStateFieldsUpdate: boolean;
 

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -205,14 +205,6 @@ export class Database {
       .getMany();
   }
 
-  async getLatestProcessedBlockProgress (repo: Repository<BlockProgressInterface>, isPruned: boolean): Promise<BlockProgressInterface | undefined> {
-    return repo.createQueryBuilder('block_progress')
-      .where('is_pruned = :isPruned AND is_complete = :isComplete', { isPruned, isComplete: true })
-      .orderBy('block_number', 'DESC')
-      .limit(1)
-      .getOne();
-  }
-
   async saveBlockProgress (repo: Repository<BlockProgressInterface>, block: DeepPartial<BlockProgressInterface>): Promise<BlockProgressInterface> {
     blockProgressCount.inc(1);
 

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -93,7 +93,7 @@ export class EventWatcher {
 
     // Check if filter for logs is enabled
     // Check if starting block for watcher is before latest canonical block
-    if ((this._serverConfig.filterLogsByAddresses || this._serverConfig.filterLogsByTopics) && startBlockNumber < latestCanonicalBlockNumber) {
+    if (this._serverConfig.useBlockRanges && startBlockNumber < latestCanonicalBlockNumber) {
       await this.startHistoricalBlockProcessing(startBlockNumber, latestCanonicalBlockNumber);
 
       return;
@@ -237,6 +237,7 @@ export class EventWatcher {
 
     // Check if publish is set to true
     // Events and blocks are not published in historical processing
+    // GQL subscription events will not be triggered if publish is set to false
     if (publish) {
       assert(blockHash);
 

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -334,7 +334,7 @@ export class Indexer {
     }
 
     // Sort logs according to blockhash
-    const blockLogsMap = this._reduceLogsToblockLogsMap(logs);
+    const blockLogsMap = this._reduceLogsToBlockLogsMap(logs);
 
     // Fetch transactions for given blocks
     const transactionsMap: Map<string, any> = new Map();
@@ -400,7 +400,7 @@ export class Indexer {
       topics
     });
 
-    const blockLogsMap = this._reduceLogsToblockLogsMap(logs);
+    const blockLogsMap = this._reduceLogsToBlockLogsMap(logs);
 
     // Fetch blocks with transactions for the logs returned
     console.time(`time:indexer#fetchAndSaveFilteredEventsAndBlocks-fetch-blocks-txs-${fromBlock}-${toBlock}`);
@@ -448,7 +448,7 @@ export class Indexer {
     return blocksWithDbEvents;
   }
 
-  _reduceLogsToblockLogsMap (logs: any[]): Map<string, any> {
+  _reduceLogsToBlockLogsMap (logs: any[]): Map<string, any> {
     return logs.reduce((acc: Map<string, any>, log: any) => {
       const { blockHash: logBlockHash } = log;
       assert(typeof logBlockHash === 'string');

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -30,7 +30,8 @@ import {
   createCheckpointJob,
   processBatchEvents,
   PrefetchedBlock,
-  fetchBlocksAtHeight
+  fetchBlocksAtHeight,
+  fetchAndSaveFilteredLogsAndBlocks
 } from './common';
 import { lastBlockNumEvents, lastBlockProcessDuration, lastProcessedBlockNumber } from './metrics';
 
@@ -52,6 +53,7 @@ export class JobRunner {
   _jobQueueConfig: JobQueueConfig;
   _blockProcessStartTime?: Date;
   _endBlockProcessTimer?: () => void;
+  // TODO: Check and remove events (always set to empty list as fetched from DB) from map structure
   _blockAndEventsMap: Map<string, PrefetchedBlock> = new Map();
 
   _shutDown = false;
@@ -150,10 +152,14 @@ export class JobRunner {
   async processHistoricalBlocks (job: PgBoss.JobWithDoneCallback<HistoricalJobData, HistoricalJobData>): Promise<void> {
     const { data: { blockNumber: startBlock } } = job;
     const endBlock = startBlock + HISTORICAL_BLOCKS_BATCH_SIZE;
-
     log(`Processing historical blocks from ${startBlock} to ${endBlock}`);
-    // TODO: Use method from common.ts to fetch and save filtered logs and blocks
-    const blocks: BlockProgressInterface[] = [];
+
+    const blocks = await fetchAndSaveFilteredLogsAndBlocks(
+      this._indexer,
+      this._blockAndEventsMap,
+      startBlock,
+      endBlock
+    );
 
     // Push event processing job for each block
     const pushJobForBlockPromises = blocks.map(async block => this.jobQueue.pushJob(

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -168,6 +168,8 @@ export class JobRunner {
       {
         kind: JOB_KIND_EVENTS,
         blockHash: block.blockHash,
+        // Avoid publishing GQL subscription event in historical processing
+        // Publishing when realtime processing is listening to events will cause problems
         publish: false
       }
     ));

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -45,6 +45,7 @@ export const HISTORICAL_BLOCKS_BATCH_SIZE = 100;
 
 export interface HistoricalJobData {
   blockNumber: number;
+  processingEndBlockNumber: number;
 }
 
 export class JobRunner {
@@ -150,8 +151,8 @@ export class JobRunner {
   }
 
   async processHistoricalBlocks (job: PgBoss.JobWithDoneCallback<HistoricalJobData, HistoricalJobData>): Promise<void> {
-    const { data: { blockNumber: startBlock } } = job;
-    const endBlock = startBlock + HISTORICAL_BLOCKS_BATCH_SIZE;
+    const { data: { blockNumber: startBlock, processingEndBlockNumber } } = job;
+    const endBlock = Math.min(startBlock + HISTORICAL_BLOCKS_BATCH_SIZE, processingEndBlockNumber);
     log(`Processing historical blocks from ${startBlock} to ${endBlock}`);
 
     const blocks = await fetchAndSaveFilteredLogsAndBlocks(

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -168,7 +168,7 @@ export class JobRunner {
       {
         kind: JOB_KIND_EVENTS,
         blockHash: block.blockHash,
-        publish: true
+        publish: false
       }
     ));
 
@@ -550,11 +550,7 @@ export class JobRunner {
       await wait(EVENTS_PROCESSING_RETRY_WAIT);
       await this.jobQueue.pushJob(
         QUEUE_EVENT_PROCESSING,
-        {
-          kind: JOB_KIND_EVENTS,
-          blockHash: blockHash,
-          publish: true
-        },
+        job.data,
         {
           priority: 1
         }

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -91,7 +91,6 @@ export interface IndexerInterface {
   getStateSyncStatus (): Promise<StateSyncStatusInterface | undefined>
   getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<any>
   getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgressInterface[]>
-  getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgressInterface | undefined>
   getLatestCanonicalBlock (): Promise<BlockProgressInterface | undefined>
   getLatestStateIndexedBlock (): Promise<BlockProgressInterface>
   getBlockEvents (blockHash: string, where: Where, queryOptions: QueryOptions): Promise<Array<EventInterface>>

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -98,6 +98,7 @@ export interface IndexerInterface {
   getAncestorAtDepth (blockHash: string, depth: number): Promise<string>
   fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgressInterface>[]): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
   saveBlockAndFetchEvents (block: DeepPartial<BlockProgressInterface>): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]>
+  fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
   removeUnknownEvents (block: BlockProgressInterface): Promise<void>
   updateBlockProgress (block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface>
   updateSyncStatusChainHead (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Fix async block size data caching running for missing block range in historical processing
- Fetch logs by filter first and then fetch only required blocks in historical processing
- Avoid publishing events and blocks in historical processing
  - Publishing block in historical processing affects realtime processing once it is started
- Fetch full block data only if subgraph block handler is configured
- Add `useBlockRanges` flag for running historical blocks processing