### PR TITLE
Handle subgraph template create when `filterLogsByAddresses` set to true

### DIFF
--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -30,8 +30,8 @@
   filterLogsByTopics = false
 
   # Boolean to switch between modes of processing events when starting the server.
-  # Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
-  # Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
+  # Setting to true will fetch filtered events and required blocks in a range of blocks and then process them.
+  # Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head).
   useBlockRanges = true
 
   # Max block range for which to return events in eventsInRange GQL query.

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -119,6 +119,14 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
+  async fetchEventsForContracts (blockHash: string, blockNumber: number, addresses: string[]): Promise<DeepPartial<EventInterface>[]> {
+    assert(blockHash);
+    assert(blockNumber);
+    assert(addresses);
+
+    return [];
+  }
+
   async saveBlockAndFetchEvents (block: BlockProgressInterface): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]> {
     return [block, []];
   }

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -206,8 +206,8 @@ export interface ServerConfig {
   clearEntitiesCacheInterval: number;
 
   // Boolean to switch between modes of processing events when starting the server.
-  // Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
-  // Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
+  // Setting to true will fetch filtered events and required blocks in a range of blocks and then process them.
+  // Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head).
   useBlockRanges: boolean;
 
   // Boolean to skip updating entity fields required in state creation and not required in the frontend.

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -128,8 +128,8 @@ export class JobQueue {
     );
   }
 
-  async markComplete (job: PgBoss.Job): Promise<void> {
-    this._boss.complete(job.id);
+  async markComplete (job: PgBoss.Job, data: object = {}): Promise<void> {
+    this._boss.complete(job.id, { ...job.data, ...data });
   }
 
   async pushJob (queue: string, job: any, options: PgBoss.PublishOptions = {}): Promise<void> {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -98,6 +98,7 @@ export interface IndexerInterface {
   fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgressInterface>[]): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
   saveBlockAndFetchEvents (block: DeepPartial<BlockProgressInterface>): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]>
   fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
+  fetchEventsForContracts (blockHash: string, blockNumber: number, addresses: string[]): Promise<DeepPartial<EventInterface>[]>
   removeUnknownEvents (block: BlockProgressInterface): Promise<void>
   updateBlockProgress (block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface>
   updateSyncStatusChainHead (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
@@ -108,7 +109,7 @@ export interface IndexerInterface {
   updateStateSyncStatusCheckpointBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface>
   markBlocksAsPruned (blocks: BlockProgressInterface[]): Promise<void>
   saveEventEntity (dbEvent: EventInterface): Promise<EventInterface>
-  saveEvents (dbEvents: EventInterface[]): Promise<void>
+  saveEvents (dbEvents: DeepPartial<EventInterface>[]): Promise<void>
   processEvent (event: EventInterface): Promise<void>
   parseEventNameAndArgs?: (kind: string, logObj: any) => any
   isWatchedContract: (address: string) => ContractInterface | undefined;


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Refetch logs in events processing when `filterLogsByAddresses` flag is set to true
- Add constant `HISTORICAL_MAX_FETCH_AHEAD` to avoid fetching too many blocks ahead of events processing
- TODOs to be fulfilled in follow on PRs:
  - Wait for events processing to complete before moving ahead with historical processing for further blocks
  - Make `HISTORICAL_MAX_FETCH_AHEAD` configurable
  - Handle template create in non subgraph order of events processing