### PR TITLE
Wait for events processing to complete before continuing historical blocks processing 

### DIFF
--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -135,6 +135,12 @@ export class BaseCmd {
     // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
     // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
     const pubsub = new PubSub();
-    this._eventWatcher = new EventWatcher(this._config.server, this._clients.ethClient, this._indexer, pubsub, this._jobQueue);
+
+    const config = {
+      server: this._config.server,
+      jobQueue: this._config.jobQueue
+    };
+
+    this._eventWatcher = new EventWatcher(config, this._clients.ethClient, this._indexer, pubsub, this._jobQueue);
   }
 }

--- a/packages/cli/src/job-runner.ts
+++ b/packages/cli/src/job-runner.ts
@@ -108,7 +108,7 @@ export class JobRunnerCmd {
 
     const jobRunner = new JobRunner(config.jobQueue, indexer, jobQueue);
 
-    await jobRunner.jobQueue.deleteAllJobs();
+    await jobRunner.jobQueue.deleteAllJobs('completed');
     await jobRunner.resetToPrevIndexedBlock();
 
     await startJobRunner(jobRunner);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -281,8 +281,8 @@ export class ServerCmd {
     assert(eventWatcher);
 
     if (config.server.kind === KIND_ACTIVE) {
-      // Delete jobs to prevent creating jobs after completion of processing previous block.
-      await jobQueue.deleteAllJobs();
+      // Delete jobs before completed state to prevent creating jobs after completion of processing previous block.
+      await jobQueue.deleteAllJobs('completed');
       await eventWatcher.start();
     }
 

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -92,3 +92,10 @@
   blockDelayInMilliSecs = 2000
   prefetchBlocksInMem = true
   prefetchBlockCount = 10
+
+  # Block range in which logs are fetched during historical blocks processing
+  historicalLogsBlockRange = 2000
+
+  # Max block range of historical processing after which it waits for completion of events processing
+  # If set to -1 historical processing does not wait for events processing and completes till latest canonical block
+  historicalMaxFetchAhead = 10000

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -24,6 +24,11 @@ export interface JobQueueConfig {
   blockDelayInMilliSecs: number;
   prefetchBlocksInMem: boolean;
   prefetchBlockCount: number;
+  // Block range in which logs are fetched during historical blocks processing
+  historicalLogsBlockRange?: number;
+  // Max block range of historical processing after which it waits for completion of events processing
+  // If set to -1 historical processing does not wait for events processing and completes till latest canonical block
+  historicalMaxFetchAhead?: number;
 }
 
 export interface GQLCacheConfig {

--- a/packages/util/src/misc.ts
+++ b/packages/util/src/misc.ts
@@ -132,7 +132,7 @@ export const resetJobs = async (config: Config): Promise<void> => {
 
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
-  await jobQueue.deleteAllJobs();
+  await jobQueue.deleteAllJobs('completed');
 };
 
 export const getResetYargs = (): yargs.Argv => {


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Wait for events queue to be empty before historical processing moves on to next block range
- Make `historicalLogsBlockRange` and `historicalMaxFetchAhead` configurable
- Perform single `eth_getLogs` RPC request for multiple addresses