### PR TITLE
Handle restarts during historical processing in watcher

### DIFF
--- a/packages/cli/src/job-runner.ts
+++ b/packages/cli/src/job-runner.ts
@@ -114,7 +114,8 @@ export class JobRunnerCmd {
 
     // Delete all active and pending (before completed) jobs to start job-runner without old queued jobs
     await jobRunner.jobQueue.deleteAllJobs('completed');
-    await jobRunner.resetToPrevIndexedBlock();
+
+    await jobRunner.resetToLatestProcessedBlock();
     await indexer.updateSyncStatusIndexingError(false);
 
     await startJobRunner(jobRunner);

--- a/packages/codegen/src/data/entities/SyncStatus.yaml
+++ b/packages/codegen/src/data/entities/SyncStatus.yaml
@@ -27,6 +27,17 @@ columns:
     pgType: integer
     tsType: number
     columnType: Column
+  - name: latestProcessedBlockHash
+    pgType: varchar
+    tsType: string
+    columnType: Column
+    columnOptions:
+      - option: length
+        value: 66
+  - name: latestProcessedBlockNumber
+    pgType: integer
+    tsType: number
+    columnType: Column
   - name: latestCanonicalBlockHash
     pgType: varchar
     tsType: string

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -460,16 +460,28 @@ export class Schema {
   }
 
   _addMeta (): void {
-    const typeComposer = this._composer.createObjectTC({
+    // Create the Block type.
+    const metaBlocktypeComposer = this._composer.createObjectTC({
+      name: '_MetaBlock_',
+      fields: {
+        hash: 'Bytes',
+        number: 'Int!',
+        timestamp: 'Int'
+      }
+    });
+
+    this._composer.addSchemaMustHaveType(metaBlocktypeComposer);
+
+    const metaTypeComposer = this._composer.createObjectTC({
       name: '_Meta_',
       fields: {
-        block: this._composer.getOTC('_Block_').NonNull,
+        block: metaBlocktypeComposer.NonNull,
         deployment: { type: new GraphQLNonNull(GraphQLString) },
         hasIndexingErrors: { type: new GraphQLNonNull(GraphQLBoolean) }
       }
     });
 
-    this._composer.addSchemaMustHaveType(typeComposer);
+    this._composer.addSchemaMustHaveType(metaTypeComposer);
 
     this._composer.Query.addFields({
       _meta: {

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -253,10 +253,10 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.updateSyncStatusChainHead(repo, blockHash, blockNumber, force);
   }
 
-  async forceUpdateSyncStatus (queryRunner: QueryRunner, blockHash: string, blockNumber: number): Promise<SyncStatus> {
+  async updateSyncStatusProcessedBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force = false): Promise<SyncStatus> {
     const repo = queryRunner.manager.getRepository(SyncStatus);
 
-    return this._baseDatabase.forceUpdateSyncStatus(repo, blockHash, blockNumber);
+    return this._baseDatabase.updateSyncStatusProcessedBlock(repo, blockHash, blockNumber, force);
   }
 
   async updateSyncStatusIndexingError (queryRunner: QueryRunner, hasIndexingError: boolean): Promise<SyncStatus | undefined> {

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -259,7 +259,7 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.forceUpdateSyncStatus(repo, blockHash, blockNumber);
   }
 
-  async updateSyncStatusIndexingError (queryRunner: QueryRunner, hasIndexingError: boolean): Promise<SyncStatus> {
+  async updateSyncStatusIndexingError (queryRunner: QueryRunner, hasIndexingError: boolean): Promise<SyncStatus | undefined> {
     const repo = queryRunner.manager.getRepository(SyncStatus);
 
     return this._baseDatabase.updateSyncStatusIndexingError(repo, hasIndexingError);

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -661,8 +661,8 @@ export class Indexer implements IndexerInterface {
     return syncStatus;
   }
 
-  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatus> {
-    return this._baseIndexer.forceUpdateSyncStatus(blockHash, blockNumber);
+  async updateSyncStatusProcessedBlock (blockHash: string, blockNumber: number, force = false): Promise<SyncStatus> {
+    return this._baseIndexer.updateSyncStatusProcessedBlock(blockHash, blockNumber, force);
   }
 
   async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatus | undefined> {

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -665,7 +665,7 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.forceUpdateSyncStatus(blockHash, blockNumber);
   }
 
-  async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatus> {
+  async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatus | undefined> {
     return this._baseIndexer.updateSyncStatusIndexingError(hasIndexingError);
   }
 

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -177,10 +177,10 @@ export class Indexer implements IndexerInterface {
     return {} as SyncStatusInterface;
   }
 
-  async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatusInterface> {
+  async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatusInterface | undefined> {
     assert(hasIndexingError);
 
-    return {} as SyncStatusInterface;
+    return undefined;
   }
 
   async markBlocksAsPruned (blocks: BlockProgressInterface[]): Promise<void> {

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -170,9 +170,10 @@ export class Indexer implements IndexerInterface {
     return {} as SyncStatusInterface;
   }
 
-  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatusInterface> {
+  async updateSyncStatusProcessedBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface> {
     assert(blockNumber);
     assert(blockHash);
+    assert(force);
 
     return {} as SyncStatusInterface;
   }

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -285,8 +285,8 @@ export class EthClient implements EthClientInterface {
           'eth_getLogs',
           [{
             address: addresses.map(address => address.toLowerCase()),
-            fromBlock: fromBlock && utils.hexlify(fromBlock),
-            toBlock: toBlock && utils.hexlify(toBlock),
+            fromBlock: fromBlock && utils.hexValue(fromBlock),
+            toBlock: toBlock && utils.hexValue(toBlock),
             blockHash,
             topics
           }]

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -384,20 +384,20 @@ const _processEventsInSubgraphOrder = async (indexer: IndexerInterface, block: B
 
   // Check if we are out of events.
   while (numFetchedEvents < block.numEvents) {
-    console.time('time:common#processEventsInSubgraphOrder-fetching_events_batch');
+    console.time(`time:common#processEventsInSubgraphOrder-fetching_events_batch-${block.blockNumber}`);
 
     // Fetch events in batches
     const events = await _getEventsBatch(indexer, block.blockHash, eventsInBatch, page);
     page++;
     numFetchedEvents += events.length;
 
-    console.timeEnd('time:common#processEventsInSubgraphOrder-fetching_events_batch');
+    console.timeEnd(`time:common#processEventsInSubgraphOrder-fetching_events_batch-${block.blockNumber}`);
 
     if (events.length) {
       log(`Processing events batch from index ${events[0].index} to ${events[0].index + events.length - 1}`);
     }
 
-    console.time('time:common#processEventsInSubgraphOrder-processing_events_batch');
+    console.time(`time:common#processEventsInSubgraphOrder-processing_events_batch-${block.blockNumber}`);
 
     // First process events for initially watched contracts
     const watchedContractEvents: EventInterface[] = [];
@@ -417,7 +417,7 @@ const _processEventsInSubgraphOrder = async (indexer: IndexerInterface, block: B
       block.numProcessedEvents++;
     }
 
-    console.timeEnd('time:common#processEventsInSubgraphOrder-processing_events_batch');
+    console.timeEnd(`time:common#processEventsInSubgraphOrder-processing_events_batch-${block.blockNumber}`);
   }
 
   const watchedContracts = indexer.getWatchedContracts().map(contract => contract.address);

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -6,7 +6,6 @@ import assert from 'assert';
 import debug from 'debug';
 import { PubSub } from 'graphql-subscriptions';
 import PgBoss from 'pg-boss';
-import { constants } from 'ethers';
 
 import { JobQueue } from './job-queue';
 import { BlockProgressInterface, EventInterface, IndexerInterface, EthClient, EventsJobData, EventsQueueJobKind } from './types';
@@ -227,17 +226,6 @@ export class EventWatcher {
 
     // endBlock exists if isComplete is true
     assert(batchEndBlockNumber);
-
-    const [block] = await this._indexer.getBlocks({ blockNumber: batchEndBlockNumber });
-    const batchEndBlockHash = block ? block.blockHash : constants.AddressZero;
-
-    // Update sync status chain head and canonical block to end block of historical processing
-    const [syncStatus] = await Promise.all([
-      this._indexer.updateSyncStatusCanonicalBlock(batchEndBlockHash, batchEndBlockNumber, true),
-      this._indexer.updateSyncStatusIndexedBlock(batchEndBlockHash, batchEndBlockNumber, true),
-      this._indexer.updateSyncStatusChainHead(batchEndBlockHash, batchEndBlockNumber, true)
-    ]);
-    log(`Sync status canonical block updated to ${syncStatus.latestCanonicalBlockNumber}`);
 
     const nextBatchStartBlockNumber = batchEndBlockNumber + 1;
     log(`Historical block processing completed for block range: ${blockNumber} to ${batchEndBlockNumber}`);

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -247,12 +247,12 @@ export class Indexer {
     return res;
   }
 
-  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatusInterface> {
+  async updateSyncStatusProcessedBlock (blockHash: string, blockNumber: number, force = false): Promise<SyncStatusInterface> {
     const dbTx = await this._db.createTransactionRunner();
     let res;
 
     try {
-      res = await this._db.forceUpdateSyncStatus(dbTx, blockHash, blockNumber);
+      res = await this._db.updateSyncStatusProcessedBlock(dbTx, blockHash, blockNumber, force);
       await dbTx.commitTransaction();
     } catch (error) {
       await dbTx.rollbackTransaction();
@@ -264,7 +264,7 @@ export class Indexer {
     return res;
   }
 
-  async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatusInterface> {
+  async updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatusInterface | undefined> {
     const dbTx = await this._db.createTransactionRunner();
     let res;
 
@@ -1318,6 +1318,10 @@ export class Indexer {
 
       if (syncStatus.latestIndexedBlockNumber > blockProgress.blockNumber) {
         await this.updateSyncStatusIndexedBlock(blockProgress.blockHash, blockProgress.blockNumber, true);
+      }
+
+      if (syncStatus.latestProcessedBlockNumber > blockProgress.blockNumber) {
+        await this.updateSyncStatusProcessedBlock(blockProgress.blockHash, blockProgress.blockNumber, true);
       }
 
       if (syncStatus.latestCanonicalBlockNumber > blockProgress.blockNumber) {

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -92,11 +92,9 @@ export type ResultEvent = {
 
 export type ResultMeta = {
   block: {
-    cid: string | null;
-    hash: string;
+    hash: string | null;
     number: number;
-    timestamp: number;
-    parentHash: string;
+    timestamp: number | null;
   };
   deployment: string;
   hasIndexingErrors: boolean;
@@ -146,37 +144,42 @@ export class Indexer {
   }
 
   async getMetaData (block: BlockHeight): Promise<ResultMeta | null> {
-    let resultBlock: BlockProgressInterface | undefined;
+    const resultBlock: ResultMeta['block'] = {
+      hash: block.hash ?? null,
+      number: block.number ?? 0,
+      timestamp: null
+    };
 
     const syncStatus = await this.getSyncStatus();
     assert(syncStatus);
 
     if (block.hash) {
-      resultBlock = await this.getBlockProgress(block.hash);
+      const blockProgress = await this.getBlockProgress(block.hash);
+      assert(blockProgress, 'No block with hash found');
+      resultBlock.number = blockProgress.blockNumber;
+      resultBlock.timestamp = blockProgress.blockTimestamp;
     } else {
-      const blockHeight = block.number ? block.number : syncStatus.latestIndexedBlockNumber - 1;
+      let blockHeight = block.number;
+
+      if (!blockHeight) {
+        blockHeight = syncStatus.latestProcessedBlockNumber;
+      }
 
       // Get all the blocks at a height
-      const blocksAtHeight = await this.getBlocksAtHeight(blockHeight, false);
+      const [blockProgress] = await this.getBlocksAtHeight(blockHeight, false);
 
-      if (blocksAtHeight.length) {
-        resultBlock = blocksAtHeight[0];
+      if (blockProgress) {
+        resultBlock.hash = blockProgress.blockHash;
+        resultBlock.number = blockProgress.blockNumber;
+        resultBlock.timestamp = blockProgress.blockTimestamp;
       }
     }
 
-    return resultBlock
-      ? {
-        block: {
-          cid: resultBlock.cid,
-          number: resultBlock.blockNumber,
-          hash: resultBlock.blockHash,
-          timestamp: resultBlock.blockTimestamp,
-          parentHash: resultBlock.parentHash
-        },
-        deployment: '',
-        hasIndexingErrors: syncStatus.hasIndexingError
-      }
-      : null;
+    return {
+      block: resultBlock,
+      hasIndexingErrors: syncStatus.hasIndexingError,
+      deployment: ''
+    };
   }
 
   async getSyncStatus (): Promise<SyncStatusInterface | undefined> {

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -15,7 +15,7 @@ interface Config {
 
 type JobCallback = (job: PgBoss.JobWithDoneCallback<any, any>) => Promise<void>;
 
-const JOBS_PER_INTERVAL = 5;
+const DEFAULT_JOBS_PER_INTERVAL = 5;
 
 const log = debug('vulcanize:job-queue');
 
@@ -86,12 +86,13 @@ export class JobQueue {
     await this._boss.stop();
   }
 
-  async subscribe (queue: string, callback: JobCallback): Promise<string> {
+  async subscribe (queue: string, callback: JobCallback, subscribeOptions: PgBoss.SubscribeOptions = {}): Promise<string> {
     return await this._boss.subscribe(
       queue,
       {
-        teamSize: JOBS_PER_INTERVAL,
-        teamConcurrency: 1
+        teamSize: DEFAULT_JOBS_PER_INTERVAL,
+        teamConcurrency: 1,
+        ...subscribeOptions
       },
       async (job) => {
         try {
@@ -111,7 +112,7 @@ export class JobQueue {
     return await this._boss.onComplete(
       queue,
       {
-        teamSize: JOBS_PER_INTERVAL,
+        teamSize: DEFAULT_JOBS_PER_INTERVAL,
         teamConcurrency: 1
       },
       async (job: PgBoss.JobWithDoneCallback<any, any>) => {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -39,6 +39,8 @@ export interface SyncStatusInterface {
   chainHeadBlockNumber: number;
   latestIndexedBlockHash: string;
   latestIndexedBlockNumber: number;
+  latestProcessedBlockHash: string;
+  latestProcessedBlockNumber: number;
   latestCanonicalBlockHash: string;
   latestCanonicalBlockNumber: number;
   initialIndexedBlockHash: string;
@@ -107,8 +109,8 @@ export interface IndexerInterface {
   updateSyncStatusChainHead (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateSyncStatusIndexedBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateSyncStatusCanonicalBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
-  forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatusInterface>
-  updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatusInterface>
+  updateSyncStatusIndexingError (hasIndexingError: boolean): Promise<SyncStatusInterface | undefined>
+  updateSyncStatusProcessedBlock (blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>
   updateStateSyncStatusIndexedBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface | undefined>
   updateStateSyncStatusCheckpointBlock (blockNumber: number, force?: boolean): Promise<StateSyncStatusInterface>
   markBlocksAsPruned (blocks: BlockProgressInterface[]): Promise<void>
@@ -171,8 +173,8 @@ export interface DatabaseInterface {
   updateSyncStatusIndexedBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
   updateSyncStatusChainHead (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
   updateSyncStatusCanonicalBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
-  forceUpdateSyncStatus (queryRunner: QueryRunner, blockHash: string, blockNumber: number): Promise<SyncStatusInterface>;
-  updateSyncStatusIndexingError (queryRunner: QueryRunner, hasIndexingError: boolean): Promise<SyncStatusInterface>;
+  updateSyncStatusIndexingError (queryRunner: QueryRunner, hasIndexingError: boolean): Promise<SyncStatusInterface | undefined>;
+  updateSyncStatusProcessedBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
   saveEvents (queryRunner: QueryRunner, events: DeepPartial<EventInterface>[]): Promise<void>;
   saveBlockWithEvents (queryRunner: QueryRunner, block: DeepPartial<BlockProgressInterface>, events: DeepPartial<EventInterface>[]): Promise<BlockProgressInterface>;
   saveEventEntity (queryRunner: QueryRunner, entity: EventInterface): Promise<EventInterface>;


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Add `latestProcessedBlockNumber` and `latestProcessedBlockHash` to sync status
- Reset job-runner to latest processed block on watcher restarts
- During historical processing update sync status in job-runner for handling server restarts
- Use sync status latest processed block for subgraph `_meta` query
- Set jobs per interval in events job queue subscription to 1