### PR TITLE
Handle tsvector type columns when forming the db query

### DIFF
--- a/packages/util/src/graph/database.ts
+++ b/packages/util/src/graph/database.ts
@@ -512,6 +512,10 @@ export class GraphDatabase {
       .from(`(${subQuery.getQuery()})`, 'latestEntities')
       .setParameters(subQuery.getParameters()) as SelectQueryBuilder<Entity>;
 
+    if (queryOptions.tsRankBy) {
+      selectQueryBuilder = this._baseDatabase.orderTsQuery(repo, selectQueryBuilder, queryOptions, 'subTable_');
+    }
+
     if (queryOptions.orderBy) {
       selectQueryBuilder = await this._baseDatabase.orderQuery(repo, selectQueryBuilder, queryOptions, relationsMap.get(entityType), block, 'subTable_');
       if (queryOptions.orderBy !== 'id') {
@@ -586,6 +590,10 @@ export class GraphDatabase {
 
     selectQueryBuilder = this._baseDatabase.buildQuery(repo, selectQueryBuilder, where, relationsMap.get(entityType), block);
 
+    if (queryOptions.tsRankBy) {
+      selectQueryBuilder = this._baseDatabase.orderTsQuery(repo, selectQueryBuilder, queryOptions);
+    }
+
     if (queryOptions.orderBy) {
       selectQueryBuilder = await this._baseDatabase.orderQuery(repo, selectQueryBuilder, queryOptions, relationsMap.get(entityType), block);
     }
@@ -648,6 +656,10 @@ export class GraphDatabase {
 
     selectQueryBuilder = this._baseDatabase.buildQuery(repo, selectQueryBuilder, where, relationsMap.get(entityType), {}, 'latest');
 
+    if (queryOptions.tsRankBy) {
+      selectQueryBuilder = this._baseDatabase.orderTsQuery(repo, selectQueryBuilder, queryOptions, '', 'latest');
+    }
+
     if (queryOptions.orderBy) {
       selectQueryBuilder = await this._baseDatabase.orderQuery(repo, selectQueryBuilder, queryOptions, relationsMap.get(entityType), {}, '', 'latest');
     }
@@ -703,6 +715,10 @@ export class GraphDatabase {
       ) as SelectQueryBuilder<Entity>;
 
     selectQueryBuilder = this._baseDatabase.buildQuery(latestEntityRepo, selectQueryBuilder, where, relationsMap.get(entityType), block, 'latest');
+
+    if (queryOptions.tsRankBy) {
+      selectQueryBuilder = this._baseDatabase.orderTsQuery(latestEntityRepo, selectQueryBuilder, queryOptions, '', 'latest');
+    }
 
     if (queryOptions.orderBy) {
       selectQueryBuilder = await this._baseDatabase.orderQuery(latestEntityRepo, selectQueryBuilder, queryOptions, relationsMap.get(entityType), block, '', 'latest');

--- a/packages/util/src/graph/database.ts
+++ b/packages/util/src/graph/database.ts
@@ -454,6 +454,10 @@ export class GraphDatabase {
 
     selectQueryBuilder = this._baseDatabase.buildQuery(repo, selectQueryBuilder, where, relationsMap.get(entityType), block);
 
+    if (queryOptions.tsRankBy) {
+      selectQueryBuilder = this._baseDatabase.orderTsQuery(repo, selectQueryBuilder, queryOptions);
+    }
+
     if (queryOptions.orderBy) {
       selectQueryBuilder = await this._baseDatabase.orderQuery(repo, selectQueryBuilder, queryOptions, relationsMap.get(entityType), block);
     }


### PR DESCRIPTION
Part of [Implement GQL API same as graph-node](https://www.notion.so/Implement-GQL-API-same-as-graph-node-241ea9811a244cb8a62f3ae5e69a82d6?pvs=23)

To be handled in follow on PR(s):
- Populating derived `tsvector` type columns in subgraph entities for text search
- Ordering text search results using `proximityRank`
