### PR TITLE
Prefetch block and txs in historical processing instead of fetching them in events processing

### DIFF
--- a/packages/cli/src/create-state-gql.ts
+++ b/packages/cli/src/create-state-gql.ts
@@ -129,8 +129,10 @@ export class CreateStateFromGQLCmd {
     }
 
     const blockProgress: Partial<BlockProgressInterface> = {
-      ...block,
-      blockNumber: Number(block.blockNumber)
+      cid: block.cid,
+      blockTimestamp: Number(block.timestamp),
+      blockNumber: Number(block.blockNumber),
+      blockHash: block.blockHash
     };
 
     // Get watched contracts using subgraph dataSources

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -54,7 +54,10 @@ export const initClients = async (config: Config): Promise<{
     });
   }
 
-  const ethProvider = getCustomProvider(rpcProviderEndpoint);
+  const ethProvider = getCustomProvider({
+    url: rpcProviderEndpoint,
+    allowGzip: true
+  });
 
   return {
     ethClient,

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -154,7 +154,9 @@ export class GraphWatcher {
 
     // Check if block data is already fetched by a previous event in the same block.
     if (!this._context.block || this._context.block.blockHash !== block.hash) {
+      console.time(`time:graph-watcher#handleEvent-getFullBlock-block-${block.number}`);
       this._context.block = await getFullBlock(this._ethClient, this._ethProvider, block.hash, block.number);
+      console.timeEnd(`time:graph-watcher#handleEvent-getFullBlock-block-${block.number}`);
     }
 
     const blockData = this._context.block;
@@ -208,9 +210,13 @@ export class GraphWatcher {
     };
 
     // Create ethereum event to be passed to the wasm event handler.
+    console.time(`time:graph-watcher#handleEvent-createEvent-block-${block.number}-event-${eventSignature}`);
     const ethereumEvent = await createEvent(instanceExports, contract, data);
+    console.timeEnd(`time:graph-watcher#handleEvent-createEvent-block-${block.number}-event-${eventSignature}`);
     try {
+      console.time(`time:graph-watcher#handleEvent-exec-${dataSource.name}-event-handler-${eventSignature}`);
       await this._handleMemoryError(instanceExports[eventHandler.handler](ethereumEvent), dataSource.name);
+      console.timeEnd(`time:graph-watcher#handleEvent-exec-${dataSource.name}-event-handler-${eventSignature}`);
     } catch (error) {
       this._clearCachedEntities();
       throw error;
@@ -452,7 +458,9 @@ export class GraphWatcher {
       return transaction;
     }
 
+    console.time(`time:graph-watcher#_getTransactionData-getFullTransaction-block-${blockNumber}-tx-${txHash}`);
     transaction = await getFullTransaction(this._ethClient, txHash, blockNumber);
+    console.timeEnd(`time:graph-watcher#_getTransactionData-getFullTransaction-block-${blockNumber}-tx-${txHash}`);
     assert(transaction);
     this._transactionsMap.set(txHash, transaction);
 

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -31,7 +31,8 @@ import {
   FILTER_CHANGE_BLOCK,
   Where,
   Filter,
-  OPERATOR_MAP
+  OPERATOR_MAP,
+  ExtraEventData
 } from '@cerc-io/util';
 
 import { Context, GraphData, instantiate } from './loader';
@@ -149,13 +150,13 @@ export class GraphWatcher {
     }
   }
 
-  async handleEvent (eventData: any) {
+  async handleEvent (eventData: any, extraData: ExtraEventData) {
     const { contract, event, eventSignature, block, tx: { hash: txHash }, eventIndex } = eventData;
 
     // Check if block data is already fetched by a previous event in the same block.
     if (!this._context.block || this._context.block.blockHash !== block.hash) {
       console.time(`time:graph-watcher#handleEvent-getFullBlock-block-${block.number}`);
-      this._context.block = await getFullBlock(this._ethClient, this._ethProvider, block.hash, block.number);
+      this._context.block = getFullBlock(extraData.ethFullBlock);
       console.timeEnd(`time:graph-watcher#handleEvent-getFullBlock-block-${block.number}`);
     }
 
@@ -243,10 +244,11 @@ export class GraphWatcher {
         continue;
       }
 
-      // Check if block data is already fetched in handleEvent method for the same block.
-      if (!this._context.block || this._context.block.blockHash !== blockHash) {
-        this._context.block = await getFullBlock(this._ethClient, this._ethProvider, blockHash, blockNumber);
-      }
+      // TODO: Use extraData full block
+      // // Check if block data is already fetched in handleEvent method for the same block.
+      // if (!this._context.block || this._context.block.blockHash !== blockHash) {
+      //   this._context.block = await getFullBlock(this._ethClient, this._ethProvider, blockHash, blockNumber);
+      // }
 
       const blockData = this._context.block;
       assert(blockData);

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -18,7 +18,9 @@ import {
   ResultEvent,
   StateKind,
   EthClient,
-  UpstreamConfig
+  UpstreamConfig,
+  EthFullTransaction,
+  EthFullBlock
 } from '@cerc-io/util';
 import { GetStorageAt, getStorageValue, MappingKey, StorageLayout } from '@cerc-io/solidity-mapper';
 
@@ -117,7 +119,12 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
-  async fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]> {
+  async fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{
+    blockProgress: BlockProgressInterface;
+    events: DeepPartial<EventInterface>[];
+    ethFullBlock: EthFullBlock;
+    ethFullTransactions: EthFullTransaction[];
+  }[]> {
     assert(startBlock);
     assert(endBlock);
 
@@ -132,8 +139,12 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
-  async saveBlockAndFetchEvents (block: BlockProgressInterface): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]> {
-    return [block, []];
+  async saveBlockAndFetchEvents (block: BlockProgressInterface): Promise<[
+    BlockProgressInterface,
+    DeepPartial<EventInterface>[],
+    EthFullTransaction[]
+  ]> {
+    return [block, [], []];
   }
 
   async removeUnknownEvents (block: BlockProgressInterface): Promise<void> {

--- a/packages/ipld-eth-client/src/eth-client.ts
+++ b/packages/ipld-eth-client/src/eth-client.ts
@@ -5,7 +5,7 @@
 import assert from 'assert';
 
 import { Cache } from '@cerc-io/cache';
-import { EthClient as EthClientInterface, FullTransaction } from '@cerc-io/util';
+import { EthClient as EthClientInterface, EthFullTransaction } from '@cerc-io/util';
 
 import ethQueries from './eth-queries';
 import { padKey } from './utils';
@@ -93,7 +93,7 @@ export class EthClient implements EthClientInterface {
 
   async getFullBlocks ({ blockNumber, blockHash }: { blockNumber?: number, blockHash?: string }): Promise<any> {
     console.time(`time:eth-client#getFullBlocks-${JSON.stringify({ blockNumber, blockHash })}`);
-    const result = await this._graphqlClient.query(
+    const { allEthHeaderCids } = await this._graphqlClient.query(
       ethQueries.getFullBlocks,
       {
         blockNumber: blockNumber?.toString(),
@@ -102,10 +102,10 @@ export class EthClient implements EthClientInterface {
     );
     console.timeEnd(`time:eth-client#getFullBlocks-${JSON.stringify({ blockNumber, blockHash })}`);
 
-    return result;
+    return allEthHeaderCids.nodes;
   }
 
-  async getFullTransaction (txHash: string, blockNumber?: number): Promise<FullTransaction> {
+  async getFullTransaction (txHash: string, blockNumber?: number): Promise<EthFullTransaction> {
     console.time(`time:eth-client#getFullTransaction-${JSON.stringify({ txHash, blockNumber })}`);
     const result = await this._graphqlClient.query(
       ethQueries.getFullTransaction,

--- a/packages/ipld-eth-client/src/eth-queries.ts
+++ b/packages/ipld-eth-client/src/eth-queries.ts
@@ -75,6 +75,7 @@ query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
 }
 `;
 
+// TODO: Get size from ipld-eth-server
 export const getFullBlocks = gql`
 query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
   allEthHeaderCids(condition: { blockNumber: $blockNumber, blockHash: $blockHash }) {

--- a/packages/ipld-eth-client/src/eth-queries.ts
+++ b/packages/ipld-eth-client/src/eth-queries.ts
@@ -75,7 +75,7 @@ query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
 }
 `;
 
-// TODO: Get size from ipld-eth-server
+// TODO: Get block size from ipld-eth-server
 export const getFullBlocks = gql`
 query allEthHeaderCids($blockNumber: BigInt, $blockHash: String) {
   allEthHeaderCids(condition: { blockNumber: $blockNumber, blockHash: $blockHash }) {

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -32,7 +32,7 @@ export class EthClient implements EthClientInterface {
   constructor (config: Config) {
     const { rpcEndpoint, cache } = config;
     assert(rpcEndpoint, 'Missing RPC endpoint');
-    this._provider = new providers.JsonRpcProvider({
+    this._provider = new providers.StaticJsonRpcProvider({
       url: rpcEndpoint,
       allowGzip: true
     });
@@ -200,8 +200,8 @@ export class EthClient implements EthClientInterface {
   async getFullTransaction (txHash: string): Promise<FullTransaction> {
     console.time(`time:eth-client#getFullTransaction-${JSON.stringify({ txHash })}`);
     const tx = await this._provider.getTransaction(txHash);
-    console.timeEnd(`time:eth-client#getFullTransaction-${JSON.stringify({ txHash })}`);
     const txReceipt = await tx.wait();
+    console.timeEnd(`time:eth-client#getFullTransaction-${JSON.stringify({ txHash })}`);
 
     return {
       ethTransactionCidByTxHash: {

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -187,6 +187,7 @@ export class EthClient implements EthClientInterface {
           receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot),
           uncleRoot: this._provider.formatter.hash(rawBlock.sha3Uncles),
           bloom: escapeHexString(this._provider.formatter.hex(rawBlock.logsBloom)),
+          size: this._provider.formatter.number(rawBlock.size).toString(),
           blockByMhKey: {
             data: escapeHexString(rlpData)
           }
@@ -310,6 +311,7 @@ export class EthClient implements EthClientInterface {
       return acc;
     }, new Set<string>());
 
+    // TODO: Get tx receipt in job-runner when fetching blocks and txs
     const txReceipts = await Promise.all(Array.from(txHashesSet).map(txHash => this._provider.getTransactionReceipt(txHash)));
 
     const txReceiptMap = txReceipts.reduce((acc, txReceipt) => {

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -304,7 +304,6 @@ export class EthClient implements EthClientInterface {
       return acc;
     }, new Set<string>());
 
-    // TODO: Get tx receipt in job-runner when fetching blocks and txs
     const txReceipts = await Promise.all(Array.from(txHashesSet).map(txHash => this._provider.getTransactionReceipt(txHash)));
 
     const txReceiptMap = txReceipts.reduce((acc, txReceipt) => {

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -32,7 +32,10 @@ export class EthClient implements EthClientInterface {
   constructor (config: Config) {
     const { rpcEndpoint, cache } = config;
     assert(rpcEndpoint, 'Missing RPC endpoint');
-    this._provider = new providers.JsonRpcProvider(rpcEndpoint);
+    this._provider = new providers.JsonRpcProvider({
+      url: rpcEndpoint,
+      allowGzip: true
+    });
 
     this._cache = cache;
   }

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -6,7 +6,7 @@ import assert from 'assert';
 import { errors, providers, utils } from 'ethers';
 
 import { Cache } from '@cerc-io/cache';
-import { encodeHeader, escapeHexString, EthClient as EthClientInterface, FullTransaction } from '@cerc-io/util';
+import { encodeHeader, escapeHexString, EthClient as EthClientInterface, EthFullTransaction } from '@cerc-io/util';
 import { padKey } from '@cerc-io/ipld-eth-client';
 
 export interface Config {
@@ -174,40 +174,33 @@ export class EthClient implements EthClientInterface {
 
     const rlpData = encodeHeader(header);
 
-    const allEthHeaderCids = {
-      nodes: [
-        {
-          blockNumber: this._provider.formatter.number(rawBlock.number).toString(),
-          blockHash: this._provider.formatter.hash(rawBlock.hash),
-          parentHash: this._provider.formatter.hash(rawBlock.parentHash),
-          timestamp: this._provider.formatter.number(rawBlock.timestamp).toString(),
-          stateRoot: this._provider.formatter.hash(rawBlock.stateRoot),
-          td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty).toString(),
-          txRoot: this._provider.formatter.hash(rawBlock.transactionsRoot),
-          receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot),
-          uncleRoot: this._provider.formatter.hash(rawBlock.sha3Uncles),
-          bloom: escapeHexString(this._provider.formatter.hex(rawBlock.logsBloom)),
-          size: this._provider.formatter.number(rawBlock.size).toString(),
-          blockByMhKey: {
-            data: escapeHexString(rlpData)
-          }
-        }
-      ]
-    };
-
-    return { allEthHeaderCids };
+    return [{
+      blockNumber: this._provider.formatter.number(rawBlock.number).toString(),
+      blockHash: this._provider.formatter.hash(rawBlock.hash),
+      parentHash: this._provider.formatter.hash(rawBlock.parentHash),
+      timestamp: this._provider.formatter.number(rawBlock.timestamp).toString(),
+      stateRoot: this._provider.formatter.hash(rawBlock.stateRoot),
+      td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty).toString(),
+      txRoot: this._provider.formatter.hash(rawBlock.transactionsRoot),
+      receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot),
+      uncleRoot: this._provider.formatter.hash(rawBlock.sha3Uncles),
+      bloom: escapeHexString(this._provider.formatter.hex(rawBlock.logsBloom)),
+      size: this._provider.formatter.number(rawBlock.size).toString(),
+      blockByMhKey: {
+        data: escapeHexString(rlpData)
+      }
+    }];
   }
 
-  async getFullTransaction (txHash: string): Promise<FullTransaction> {
+  async getFullTransaction (txHash: string): Promise<EthFullTransaction> {
     console.time(`time:eth-client#getFullTransaction-${JSON.stringify({ txHash })}`);
     const tx = await this._provider.getTransaction(txHash);
-    const txReceipt = await tx.wait();
     console.timeEnd(`time:eth-client#getFullTransaction-${JSON.stringify({ txHash })}`);
 
     return {
       ethTransactionCidByTxHash: {
         txHash: tx.hash,
-        index: txReceipt.transactionIndex,
+        index: (tx as any).transactionIndex,
         src: tx.from,
         dst: tx.to
       },

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -411,7 +411,9 @@ const _processEventsInSubgraphOrder = async (indexer: IndexerInterface, block: B
 
     // Process known events in a loop
     for (const event of watchedContractEvents) {
+      console.time(`time:common#_processEventsInSubgraphOrder-block-${block.blockNumber}-processEvent-${event.eventName}`);
       await indexer.processEvent(event);
+      console.timeEnd(`time:common#_processEventsInSubgraphOrder-block-${block.blockNumber}-processEvent-${event.eventName}`);
 
       block.lastProcessedEventIndex = event.index;
       block.numProcessedEvents++;
@@ -430,7 +432,9 @@ const _processEventsInSubgraphOrder = async (indexer: IndexerInterface, block: B
     if (indexer.upstreamConfig.ethServer.filterLogsByAddresses) {
       // Fetch and parse events for newly watched contracts
       const newContracts = watchedContracts.filter(contract => !initiallyWatchedContracts.includes(contract));
+      console.time(`time:common#_processEventsInSubgraphOrder-fetchEventsForContracts-block-${block.blockNumber}-unwatched-contract`);
       const events = await indexer.fetchEventsForContracts(block.blockHash, block.blockNumber, newContracts);
+      console.timeEnd(`time:common#_processEventsInSubgraphOrder-fetchEventsForContracts-block-${block.blockNumber}-unwatched-contract`);
 
       events.forEach(event => {
         event.block = block;
@@ -457,7 +461,9 @@ const _processEventsInSubgraphOrder = async (indexer: IndexerInterface, block: B
   console.time('time:common#processEventsInSubgraphOrder-processing_initially_unwatched_events');
   // In the end process events of newly watched contracts
   for (const updatedDbEvent of updatedDbEvents) {
+    console.time(`time:common#processEventsInSubgraphOrder--block-${block.blockNumber}-updated-processEvent-${updatedDbEvent.eventName}`);
     await indexer.processEvent(updatedDbEvent);
+    console.timeEnd(`time:common#processEventsInSubgraphOrder-block-${block.blockNumber}-updated-processEvent-${updatedDbEvent.eventName}`);
 
     block.lastProcessedEventIndex = Math.max(block.lastProcessedEventIndex + 1, updatedDbEvent.index);
     block.numProcessedEvents++;

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -101,7 +101,6 @@ export const fetchBlocksAtHeight = async (
   while (!blocks.length) {
     try {
       console.time('time:common#_fetchBlocks-eth-server');
-      // TODO: Get full block and set in blockEventsMap
       blocks = await indexer.getBlocks({ blockNumber });
 
       if (!blocks.length) {

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -107,6 +107,20 @@ export const fetchBlocksAtHeight = async (
       if (!blocks.length) {
         log(`No blocks fetched for block number ${blockNumber}, retrying after ${jobQueueConfig.blockDelayInMilliSecs} ms delay.`);
         await wait(jobQueueConfig.blockDelayInMilliSecs);
+      } else {
+        blocks.forEach(block => {
+          blockAndEventsMap.set(
+            block.blockHash,
+            {
+              // Block is set later in job-runner when saving to database
+              block: {} as BlockProgressInterface,
+              events: [],
+              ethFullBlock: block,
+              // Transactions are set later in job-runner when fetching events
+              ethFullTransactions: []
+            }
+          );
+        });
       }
     } catch (err: any) {
       // Handle null block error in case of Lotus EVM

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -33,6 +33,7 @@ export class EventWatcher {
   _indexer: IndexerInterface;
   _pubsub: PubSub;
   _jobQueue: JobQueue;
+  _realtimeProcessingStarted = false;
 
   _shutDown = false;
   _signalCount = 0;
@@ -134,6 +135,13 @@ export class EventWatcher {
   async startRealtimeBlockProcessing (startBlockNumber: number): Promise<void> {
     log(`Starting realtime block processing from block ${startBlockNumber}`);
     await processBlockByNumber(this._jobQueue, startBlockNumber);
+
+    // Check if realtime processing already started and avoid resubscribing to block progress event
+    if (this._realtimeProcessingStarted) {
+      return;
+    }
+
+    this._realtimeProcessingStarted = true;
 
     // Creating an AsyncIterable from AsyncIterator to iterate over the values.
     // https://www.codementor.io/@tiagolopesferreira/asynchronous-iterators-in-javascript-jl1yg8la1#for-wait-of

--- a/packages/util/src/graph/utils.ts
+++ b/packages/util/src/graph/utils.ts
@@ -34,7 +34,7 @@ export interface Transaction {
   hash: string;
   index: number;
   from: string;
-  to: string;
+  to?: string;
   value: string;
   gasLimit: string;
   gasPrice?: string;

--- a/packages/util/src/index-block.ts
+++ b/packages/util/src/index-block.ts
@@ -51,8 +51,9 @@ export const indexBlock = async (
       indexer,
       {
         block: blockProgress,
-        // TODO: Set ethFullBlock
-        ethFullBlock: {} as EthFullBlock
+        // TODO: Set ethFullBlock and ethFullTransactions
+        ethFullBlock: {} as EthFullBlock,
+        ethFullTransactions: []
       },
       { eventsInBatch, subgraphEventsOrder });
   }

--- a/packages/util/src/index-block.ts
+++ b/packages/util/src/index-block.ts
@@ -6,6 +6,7 @@ import assert from 'assert';
 
 import { BlockProgressInterface, IndexerInterface } from './types';
 import { processBatchEvents } from './common';
+import { EthFullBlock } from '.';
 
 export const indexBlock = async (
   indexer: IndexerInterface,
@@ -46,6 +47,13 @@ export const indexBlock = async (
     assert(indexer.processBlock);
     await indexer.processBlock(blockProgress);
 
-    await processBatchEvents(indexer, blockProgress, eventsInBatch, subgraphEventsOrder);
+    await processBatchEvents(
+      indexer,
+      {
+        block: blockProgress,
+        // TODO: Set ethFullBlock
+        ethFullBlock: {} as EthFullBlock
+      },
+      { eventsInBatch, subgraphEventsOrder });
   }
 };

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -291,10 +291,9 @@ export class Indexer {
     return res;
   }
 
-  async getBlocks (blockFilter: { blockNumber?: number, blockHash?: string }): Promise<any> {
+  async getBlocks (blockFilter: { blockNumber?: number, blockHash?: string }): Promise<EthFullBlock[]> {
     assert(blockFilter.blockHash || blockFilter.blockNumber);
-    const result = await this._ethClient.getBlocks(blockFilter);
-    const { allEthHeaderCids: { nodes: blocks } } = result;
+    const blocks = await this._ethClient.getFullBlocks(blockFilter);
 
     if (!blocks.length) {
       try {
@@ -570,47 +569,55 @@ export class Indexer {
   }
 
   // Fetch events (to be saved to db) for a particular block
-  async fetchEvents (blockHash: string, blockNumber: number, eventSignaturesMap: Map<string, string[]>, parseEventNameAndArgs: (kind: string, logObj: any) => any): Promise<DeepPartial<EventInterface>[]> {
+  async fetchEvents (blockHash: string, blockNumber: number, eventSignaturesMap: Map<string, string[]>, parseEventNameAndArgs: (kind: string, logObj: any) => any): Promise<{ events: DeepPartial<EventInterface>[], transactions: EthFullTransaction[]}> {
     const { addresses, topics } = this._createLogsFilters(eventSignaturesMap);
     const { logs, transactions } = await this._fetchLogsAndTransactions(blockHash, blockNumber, addresses, topics);
 
-    return this.createDbEventsFromLogsAndTxs(blockHash, logs, transactions, parseEventNameAndArgs);
+    const events = this.createDbEventsFromLogsAndTxs(
+      blockHash,
+      logs,
+      transactions.map(tx => tx.ethTransactionCidByTxHash),
+      parseEventNameAndArgs
+    );
+
+    return { events, transactions };
   }
 
   async fetchEventsForContracts (blockHash: string, blockNumber: number, addresses: string[], eventSignaturesMap: Map<string, string[]>, parseEventNameAndArgs: (kind: string, logObj: any) => any): Promise<DeepPartial<EventInterface>[]> {
     const { topics } = this._createLogsFilters(eventSignaturesMap);
     const { logs, transactions } = await this._fetchLogsAndTransactions(blockHash, blockNumber, addresses, topics);
 
-    return this.createDbEventsFromLogsAndTxs(blockHash, logs, transactions, parseEventNameAndArgs);
+    return this.createDbEventsFromLogsAndTxs(
+      blockHash,
+      logs,
+      transactions.map(tx => tx.ethTransactionCidByTxHash),
+      parseEventNameAndArgs
+    );
   }
 
-  async _fetchLogsAndTransactions (blockHash: string, blockNumber: number, addresses?: string[], topics?: string[][]): Promise<{ logs: any[]; transactions: any[] }> {
-    const logsPromise = await this._ethClient.getLogs({
+  async _fetchLogsAndTransactions (blockHash: string, blockNumber: number, addresses?: string[], topics?: string[][]): Promise<{ logs: any[]; transactions: EthFullTransaction[] }> {
+    const { logs } = await this._ethClient.getLogs({
       blockHash,
       blockNumber: blockNumber.toString(),
       addresses,
       topics
     });
 
-    // TODO: Use txs from blockEventsMap
-    const transactionsPromise = this._ethClient.getBlockWithTransactions({ blockHash, blockNumber });
-
-    const [
-      { logs },
-      {
-        allEthHeaderCids: {
-          nodes: [
-            {
-              ethTransactionCidsByHeaderId: {
-                nodes: transactions
-              }
-            }
-          ]
-        }
-      }
-    ] = await Promise.all([logsPromise, transactionsPromise]);
+    const transactions = await this._fetchTxsFromLogs(logs);
 
     return { logs, transactions };
+  }
+
+  async _fetchTxsFromLogs (logs: any[]): Promise<EthFullTransaction[]> {
+    const txHashes = Array.from([
+      ...new Set<string>(logs.map((log) => log.transaction.hash))
+    ]);
+
+    const ethFullTxPromises = txHashes.map(async txHash => {
+      return this._ethClient.getFullTransaction(txHash);
+    });
+
+    return Promise.all(ethFullTxPromises);
   }
 
   // Create events to be saved to db for a block given blockHash, logs, transactions and a parser function

--- a/packages/util/src/misc.ts
+++ b/packages/util/src/misc.ts
@@ -154,7 +154,7 @@ export const getResetYargs = (): yargs.Argv => {
 };
 
 export const getCustomProvider = (url?: utils.ConnectionInfo | string, network?: providers.Networkish): providers.JsonRpcProvider => {
-  const provider = new providers.JsonRpcProvider(url, network);
+  const provider = new providers.StaticJsonRpcProvider(url, network);
   provider.formatter = new CustomFormatter();
   return provider;
 };

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -166,14 +166,18 @@ export interface IndexerInterface {
   getEvent (id: string): Promise<EventInterface | undefined>
   getSyncStatus (): Promise<SyncStatusInterface | undefined>
   getStateSyncStatus (): Promise<StateSyncStatusInterface | undefined>
-  getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<any>
+  getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<EthFullBlock[]>
   getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgressInterface[]>
   getLatestCanonicalBlock (): Promise<BlockProgressInterface | undefined>
   getLatestStateIndexedBlock (): Promise<BlockProgressInterface>
   getBlockEvents (blockHash: string, where: Where, queryOptions: QueryOptions): Promise<Array<EventInterface>>
   getAncestorAtDepth (blockHash: string, depth: number): Promise<string>
   fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgressInterface>[]): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
-  saveBlockAndFetchEvents (block: DeepPartial<BlockProgressInterface>): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]>
+  saveBlockAndFetchEvents (block: DeepPartial<BlockProgressInterface>): Promise<[
+    BlockProgressInterface,
+    DeepPartial<EventInterface>[],
+    EthFullTransaction[]
+  ]>
   fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{
     blockProgress: BlockProgressInterface,
     events: DeepPartial<EventInterface>[],

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -9,8 +9,9 @@ import { MappingKey, StorageLayout } from '@cerc-io/solidity-mapper';
 
 import { ServerConfig, UpstreamConfig } from './config';
 import { Where, QueryOptions, Database } from './database';
-import { ValueResult, StateStatus } from './indexer';
+import { ValueResult, StateStatus, ExtraEventData } from './indexer';
 import { JOB_KIND_CONTRACT, JOB_KIND_EVENTS } from './constants';
+import { EthFullBlock } from '.';
 
 export enum StateKind {
   Diff = 'diff',
@@ -103,7 +104,7 @@ export interface IndexerInterface {
   getAncestorAtDepth (blockHash: string, depth: number): Promise<string>
   fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgressInterface>[]): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
   saveBlockAndFetchEvents (block: DeepPartial<BlockProgressInterface>): Promise<[BlockProgressInterface, DeepPartial<EventInterface>[]]>
-  fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[] }[]>
+  fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgressInterface, events: DeepPartial<EventInterface>[], ethFullBlock: EthFullBlock }[]>
   fetchEventsForContracts (blockHash: string, blockNumber: number, addresses: string[]): Promise<DeepPartial<EventInterface>[]>
   removeUnknownEvents (block: BlockProgressInterface): Promise<void>
   updateBlockProgress (block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface>
@@ -117,7 +118,7 @@ export interface IndexerInterface {
   markBlocksAsPruned (blocks: BlockProgressInterface[]): Promise<void>
   saveEventEntity (dbEvent: EventInterface): Promise<EventInterface>
   saveEvents (dbEvents: DeepPartial<EventInterface>[]): Promise<void>
-  processEvent (event: EventInterface): Promise<void>
+  processEvent (event: EventInterface, extraData: ExtraEventData): Promise<void>
   parseEventNameAndArgs?: (kind: string, logObj: any) => any
   isWatchedContract: (address: string) => ContractInterface | undefined;
   getWatchedContracts: () => ContractInterface[]


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Use ethersjs [StaticJsonRpcProvider](https://docs.ethers.org/v5/single-page/#/v5/api/providers/jsonrpc-provider/-%23-StaticJsonRpcProvider) to avoid `getNetwork` calls
- Set gzip to true for network requests in ethersjs
- Prefetch required block and txs in historical processing and cache in memory for events processing
- TODOs to be fulfilled in follow-on PRs:
  - Use prefetched block data in subgraph block handler (not configured in sushiswap v3 subgraph)