### PR TITLE
Fix switch from historical to realtime processing when template create block exists near head

### DIFF
--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -223,8 +223,15 @@ export class EventWatcher {
 
     // Check if historical processing end block is reached
     if (nextBatchStartBlockNumber > this._historicalProcessingEndBlockNumber) {
-      // Start realtime processing
-      this.startBlockProcessing();
+      const historicalProcessingQueueSize = await this._jobQueue.getQueueSize(QUEUE_HISTORICAL_PROCESSING, 'completed');
+
+      // Check that there are no active or pending historical processing jobs
+      // Might be created on encountering template create in events processing
+      if (historicalProcessingQueueSize === 0) {
+        // Start next batch of historical processing or realtime processing
+        this.startBlockProcessing();
+      }
+
       return;
     }
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -171,7 +171,9 @@ export class JobRunner {
     const { data: { blockNumber: startBlock, processingEndBlockNumber } } = job;
 
     if (this._historicalProcessingCompletedUpto) {
+      // Check if historical processing start is for a previous block which happens incase of template create
       if (startBlock < this._historicalProcessingCompletedUpto) {
+        // Delete any pending historical processing jobs
         await this.jobQueue.deleteJobs(QUEUE_HISTORICAL_PROCESSING);
 
         // Wait for events queue to be empty

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -175,7 +175,7 @@ export class JobRunner {
         await this.jobQueue.deleteJobs(QUEUE_HISTORICAL_PROCESSING);
 
         // Wait for events queue to be empty
-        log(`Waiting for events queue to be empty before restarting watcher to block ${startBlock - 1}`);
+        log(`Waiting for events queue to be empty before resetting watcher to block ${startBlock - 1}`);
         await this.jobQueue.waitForEmptyQueue(QUEUE_EVENT_PROCESSING);
 
         // Remove all watcher blocks and events data if startBlock is less than this._historicalProcessingCompletedUpto


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Fix historical processing for same block range created on encountering template create
- Fix switch from historical to realtime processing when template create block exists near head