### PR TITLE
Implement new graph-node host API for BigDecimal exponentiation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.69",
+  "version": "0.2.70",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.69",
-    "@cerc-io/ipld-eth-client": "^0.2.69",
+    "@cerc-io/cache": "^0.2.70",
+    "@cerc-io/ipld-eth-client": "^0.2.70",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.69",
-    "@cerc-io/rpc-eth-client": "^0.2.69",
-    "@cerc-io/util": "^0.2.69",
+    "@cerc-io/peer": "^0.2.70",
+    "@cerc-io/rpc-eth-client": "^0.2.70",
+    "@cerc-io/util": "^0.2.70",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.69",
+    "@cerc-io/util": "^0.2.70",
     "@graphql-tools/load-files": "^6.5.2",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",
     "@solidity-parser/parser": "^0.13.2",

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.69",
-    "@cerc-io/ipld-eth-client": "^0.2.69",
-    "@cerc-io/solidity-mapper": "^0.2.69",
-    "@cerc-io/util": "^0.2.69",
+    "@cerc-io/cli": "^0.2.70",
+    "@cerc-io/ipld-eth-client": "^0.2.70",
+    "@cerc-io/solidity-mapper": "^0.2.70",
+    "@cerc-io/util": "^0.2.70",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.69",
+    "@cerc-io/graph-node": "^0.2.70",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.69",
+    "@cerc-io/solidity-mapper": "^0.2.70",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.69",
-    "@cerc-io/ipld-eth-client": "^0.2.69",
-    "@cerc-io/util": "^0.2.69",
+    "@cerc-io/cache": "^0.2.70",
+    "@cerc-io/ipld-eth-client": "^0.2.70",
+    "@cerc-io/util": "^0.2.70",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/graph-node/src/loader.ts
+++ b/packages/graph-node/src/loader.ts
@@ -459,6 +459,25 @@ export const instantiate = async (
 
         return mulResultBigDecimal;
       },
+      'bigDecimal.pow': async (x: number, y: number) => {
+        // Create decimal x string.
+        const xBigDecimal = await BigDecimal.wrap(x);
+        const xStringPtr = await xBigDecimal.toString();
+        const xDecimalString = __getString(xStringPtr);
+        const xDecimal = new GraphDecimal(xDecimalString);
+
+        // Create decimal y string.
+        const yBigDecimal = await BigDecimal.wrap(y);
+        const yStringPtr = await yBigDecimal.toString();
+        const yDecimalString = __getString(yStringPtr);
+
+        // Perform the decimal pow operation.
+        const powResult = xDecimal.pow(yDecimalString);
+        const ptr = await __newString(powResult.toString());
+        const powResultBigDecimal = await BigDecimal.fromString(ptr);
+
+        return powResultBigDecimal;
+      },
 
       'bigInt.fromString': async (s: number) => {
         const string = __getString(s);

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.69",
-    "@cerc-io/util": "^0.2.69",
+    "@cerc-io/cache": "^0.2.70",
+    "@cerc-io/util": "^0.2.70",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.69",
-    "@cerc-io/ipld-eth-client": "^0.2.69",
-    "@cerc-io/util": "^0.2.69",
+    "@cerc-io/cache": "^0.2.70",
+    "@cerc-io/ipld-eth-client": "^0.2.70",
+    "@cerc-io/util": "^0.2.70",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -6,8 +6,10 @@ import assert from 'assert';
 import { errors, providers, utils } from 'ethers';
 
 import { Cache } from '@cerc-io/cache';
-import { encodeHeader, escapeHexString, EthClient as EthClientInterface, EthFullTransaction } from '@cerc-io/util';
+import { encodeHeader, escapeHexString, EthClient as EthClientInterface, EthFullBlock, EthFullTransaction } from '@cerc-io/util';
 import { padKey } from '@cerc-io/ipld-eth-client';
+
+const FUTURE_BLOCK_ERROR = "requested a future epoch (beyond 'latest')";
 
 export interface Config {
   cache: Cache | undefined;
@@ -125,7 +127,7 @@ export class EthClient implements EthClientInterface {
       }
     } catch (err: any) {
       // Check and ignore future block error
-      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === "requested a future epoch (beyond 'latest')")) {
+      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === FUTURE_BLOCK_ERROR)) {
         throw err;
       }
     } finally {
@@ -139,57 +141,69 @@ export class EthClient implements EthClientInterface {
     };
   }
 
-  async getFullBlocks ({ blockNumber, blockHash }: { blockNumber?: number, blockHash?: string }): Promise<any> {
+  async getFullBlocks ({ blockNumber, blockHash }: { blockNumber?: number, blockHash?: string }): Promise<EthFullBlock[]> {
     const blockNumberHex = blockNumber ? utils.hexValue(blockNumber) : undefined;
     const blockHashOrBlockNumber = blockHash ?? blockNumberHex;
     assert(blockHashOrBlockNumber);
-
     console.time(`time:eth-client#getFullBlocks-${JSON.stringify({ blockNumber, blockHash })}`);
-    const rawBlock = await this._provider.send(
-      blockHash ? 'eth_getBlockByHash' : 'eth_getBlockByNumber',
-      [blockHashOrBlockNumber, false]
-    );
-    console.timeEnd(`time:eth-client#getFullBlocks-${JSON.stringify({ blockNumber, blockHash })}`);
 
-    // Create block header
-    // https://github.com/cerc-io/go-ethereum/blob/v1.11.6-statediff-5.0.8/core/types/block.go#L64
-    const header = {
-      Parent: rawBlock.parentHash,
-      UnclesDigest: rawBlock.sha3Uncles,
-      Beneficiary: rawBlock.miner,
-      StateRoot: rawBlock.stateRoot,
-      TxRoot: rawBlock.transactionsRoot,
-      RctRoot: rawBlock.receiptsRoot,
-      Bloom: rawBlock.logsBloom,
-      Difficulty: BigInt(rawBlock.difficulty),
-      Number: BigInt(rawBlock.number),
-      GasLimit: BigInt(rawBlock.gasLimit),
-      GasUsed: BigInt(rawBlock.gasUsed),
-      Time: Number(rawBlock.timestamp),
-      Extra: rawBlock.extraData,
-      MixDigest: rawBlock.mixHash,
-      Nonce: BigInt(rawBlock.nonce),
-      BaseFee: rawBlock.baseFeePerGas && BigInt(rawBlock.baseFeePerGas)
-    };
+    try {
+      const rawBlock = await this._provider.send(
+        blockHash ? 'eth_getBlockByHash' : 'eth_getBlockByNumber',
+        [blockHashOrBlockNumber, false]
+      );
 
-    const rlpData = encodeHeader(header);
+      if (rawBlock) {
+        // Create block header
+        // https://github.com/cerc-io/go-ethereum/blob/v1.11.6-statediff-5.0.8/core/types/block.go#L64
+        const header = {
+          Parent: rawBlock.parentHash,
+          UnclesDigest: rawBlock.sha3Uncles,
+          Beneficiary: rawBlock.miner,
+          StateRoot: rawBlock.stateRoot,
+          TxRoot: rawBlock.transactionsRoot,
+          RctRoot: rawBlock.receiptsRoot,
+          Bloom: rawBlock.logsBloom,
+          Difficulty: BigInt(rawBlock.difficulty),
+          Number: BigInt(rawBlock.number),
+          GasLimit: BigInt(rawBlock.gasLimit),
+          GasUsed: BigInt(rawBlock.gasUsed),
+          Time: Number(rawBlock.timestamp),
+          Extra: rawBlock.extraData,
+          MixDigest: rawBlock.mixHash,
+          Nonce: BigInt(rawBlock.nonce),
+          BaseFee: rawBlock.baseFeePerGas && BigInt(rawBlock.baseFeePerGas)
+        };
 
-    return [{
-      blockNumber: this._provider.formatter.number(rawBlock.number).toString(),
-      blockHash: this._provider.formatter.hash(rawBlock.hash),
-      parentHash: this._provider.formatter.hash(rawBlock.parentHash),
-      timestamp: this._provider.formatter.number(rawBlock.timestamp).toString(),
-      stateRoot: this._provider.formatter.hash(rawBlock.stateRoot),
-      td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty).toString(),
-      txRoot: this._provider.formatter.hash(rawBlock.transactionsRoot),
-      receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot),
-      uncleRoot: this._provider.formatter.hash(rawBlock.sha3Uncles),
-      bloom: escapeHexString(this._provider.formatter.hex(rawBlock.logsBloom)),
-      size: this._provider.formatter.number(rawBlock.size).toString(),
-      blockByMhKey: {
-        data: escapeHexString(rlpData)
+        const rlpData = encodeHeader(header);
+
+        return [{
+          blockNumber: this._provider.formatter.number(rawBlock.number).toString(),
+          blockHash: this._provider.formatter.hash(rawBlock.hash),
+          parentHash: this._provider.formatter.hash(rawBlock.parentHash),
+          timestamp: this._provider.formatter.number(rawBlock.timestamp).toString(),
+          stateRoot: this._provider.formatter.hash(rawBlock.stateRoot),
+          td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty).toString(),
+          txRoot: this._provider.formatter.hash(rawBlock.transactionsRoot),
+          receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot),
+          uncleRoot: this._provider.formatter.hash(rawBlock.sha3Uncles),
+          bloom: escapeHexString(this._provider.formatter.hex(rawBlock.logsBloom)),
+          size: this._provider.formatter.number(rawBlock.size).toString(),
+          blockByMhKey: {
+            data: escapeHexString(rlpData)
+          }
+        }];
       }
-    }];
+    } catch (err: any) {
+      // Check and ignore future block error
+      if (!(err.code === errors.SERVER_ERROR && err.error && err.error.message === FUTURE_BLOCK_ERROR)) {
+        throw err;
+      }
+    } finally {
+      console.timeEnd(`time:eth-client#getFullBlocks-${JSON.stringify({ blockNumber, blockHash })}`);
+    }
+
+    return [];
   }
 
   async getFullTransaction (txHash: string): Promise<EthFullTransaction> {

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.69",
-    "@cerc-io/solidity-mapper": "^0.2.69",
+    "@cerc-io/peer": "^0.2.70",
+    "@cerc-io/solidity-mapper": "^0.2.70",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -52,7 +52,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.69",
+    "@cerc-io/cache": "^0.2.70",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",


### PR DESCRIPTION
Part of [Run with sushiswap v3 subgraph](https://www.notion.so/Run-with-sushiswap-v3-subgraph-23ab7c56d790487fa73adcc0b3e513fc?pvs=23)

- Add `bigDecimal.pow` host API for exponentiation
- Handle FEVM future block error in `rpc-eth-client` getFullBlocks and getBlockWithTransactions methods