### PR TITLE
Fix retry on error for events processing job with exponential backoff

### DIFF
--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -759,6 +759,19 @@ export class Indexer implements IndexerInterface {
     await this.resetLatestEntities(blockNumber);
     {{/if}}
   }
+
+  async clearProcessedBlockData (block: BlockProgress): Promise<void> {
+    {{#if (subgraphPath)}}
+    const entities = [...ENTITIES, FrothyEntity];
+    {{else}}
+    const entities = [...ENTITIES];
+    {{/if}}
+    await this._baseIndexer.clearProcessedBlockData(block, entities);
+    {{#if (subgraphPath)}}
+
+    await this.resetLatestEntities(block.blockNumber);
+    {{/if}}
+  }
   {{#if (subgraphPath)}}
 
   getEntityTypesMap (): Map<string, { [key: string]: string }> {

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -318,6 +318,10 @@ export class Indexer implements IndexerInterface {
     return undefined;
   }
 
+  async clearProcessedBlockData (block: BlockProgressInterface): Promise<void> {
+    return undefined;
+  }
+
   cacheContract (contract: ContractInterface): void {
     return undefined;
   }

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -104,8 +104,7 @@ export class EventWatcher {
       return;
     }
 
-    // const latestCanonicalBlockNumber = latestBlock.number - MAX_REORG_DEPTH;
-    const latestCanonicalBlockNumber = 3373270;
+    const latestCanonicalBlockNumber = latestBlock.number - MAX_REORG_DEPTH;
     let startBlockNumber = latestBlock.number;
 
     if (syncStatus) {

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -66,32 +66,36 @@ export class EventWatcher {
   }
 
   async initBlockProcessingOnCompleteHandler (): Promise<void> {
-    this._jobQueue.onComplete(QUEUE_BLOCK_PROCESSING, async (job) => {
-      await this.blockProcessingCompleteHandler(job);
-    });
+    this._jobQueue.onComplete(
+      QUEUE_BLOCK_PROCESSING,
+      async (job) => this.blockProcessingCompleteHandler(job)
+    );
   }
 
   async initHistoricalProcessingOnCompleteHandler (): Promise<void> {
-    this._jobQueue.onComplete(QUEUE_HISTORICAL_PROCESSING, async (job) => {
-      await this.historicalProcessingCompleteHandler(job);
-    });
+    this._jobQueue.onComplete(
+      QUEUE_HISTORICAL_PROCESSING,
+      async (job) => this.historicalProcessingCompleteHandler(job)
+    );
   }
 
   async initEventProcessingOnCompleteHandler (): Promise<void> {
-    await this._jobQueue.onComplete(QUEUE_EVENT_PROCESSING, async (job) => {
-      await this.eventProcessingCompleteHandler(job);
-    });
+    await this._jobQueue.onComplete(
+      QUEUE_EVENT_PROCESSING,
+      async (job) => this.eventProcessingCompleteHandler(job as PgBoss.JobWithMetadata),
+      { includeMetadata: true }
+    );
   }
 
   async startBlockProcessing (): Promise<void> {
     // Get latest block in chain and sync status from DB.
     const [{ block: latestBlock }, syncStatus] = await Promise.all([
       this._ethClient.getBlockByHash(),
-      this._indexer.getSyncStatus()
+      this._indexer.getSyncStatus(),
+      // Wait for events job queue to be empty before starting historical or realtime processing
+      this._jobQueue.waitForEmptyQueue(QUEUE_EVENT_PROCESSING)
     ]);
 
-    // Wait for events job queue to be empty before starting historical or realtime processing
-    await this._jobQueue.waitForEmptyQueue(QUEUE_EVENT_PROCESSING);
     const historicalProcessingQueueSize = await this._jobQueue.getQueueSize(QUEUE_HISTORICAL_PROCESSING, 'completed');
 
     // Stop if there are active or pending historical processing jobs
@@ -100,7 +104,8 @@ export class EventWatcher {
       return;
     }
 
-    const latestCanonicalBlockNumber = latestBlock.number - MAX_REORG_DEPTH;
+    // const latestCanonicalBlockNumber = latestBlock.number - MAX_REORG_DEPTH;
+    const latestCanonicalBlockNumber = 3373270;
     let startBlockNumber = latestBlock.number;
 
     if (syncStatus) {
@@ -110,14 +115,7 @@ export class EventWatcher {
     // Check if filter for logs is enabled
     // Check if starting block for watcher is before latest canonical block
     if (this._config.jobQueue.useBlockRanges && startBlockNumber < latestCanonicalBlockNumber) {
-      let endBlockNumber = latestCanonicalBlockNumber;
-      const historicalMaxFetchAhead = this._config.jobQueue.historicalMaxFetchAhead ?? DEFAULT_HISTORICAL_MAX_FETCH_AHEAD;
-
-      if (historicalMaxFetchAhead > 0) {
-        endBlockNumber = Math.min(startBlockNumber + historicalMaxFetchAhead, endBlockNumber);
-      }
-
-      await this.startHistoricalBlockProcessing(startBlockNumber, endBlockNumber);
+      await this.startHistoricalBlockProcessing(startBlockNumber, latestCanonicalBlockNumber);
 
       return;
     }
@@ -125,7 +123,19 @@ export class EventWatcher {
     await this.startRealtimeBlockProcessing(startBlockNumber);
   }
 
-  async startHistoricalBlockProcessing (startBlockNumber: number, endBlockNumber: number): Promise<void> {
+  async startHistoricalBlockProcessing (startBlockNumber: number, latestCanonicalBlockNumber: number): Promise<void> {
+    if (this._realtimeProcessingStarted) {
+      // Do not start historical processing if realtime processing has already started
+      return;
+    }
+
+    let endBlockNumber = latestCanonicalBlockNumber;
+    const historicalMaxFetchAhead = this._config.jobQueue.historicalMaxFetchAhead ?? DEFAULT_HISTORICAL_MAX_FETCH_AHEAD;
+
+    if (historicalMaxFetchAhead > 0) {
+      endBlockNumber = Math.min(startBlockNumber + historicalMaxFetchAhead, endBlockNumber);
+    }
+
     this._historicalProcessingEndBlockNumber = endBlockNumber;
     log(`Starting historical block processing in batches from ${startBlockNumber} up to block ${this._historicalProcessingEndBlockNumber}`);
 
@@ -140,7 +150,7 @@ export class EventWatcher {
   }
 
   async startRealtimeBlockProcessing (startBlockNumber: number): Promise<void> {
-    // Check if realtime processing already started and avoid resubscribing to block progress event
+    // Check if realtime processing already started
     if (this._realtimeProcessingStarted) {
       return;
     }
@@ -246,8 +256,8 @@ export class EventWatcher {
     );
   }
 
-  async eventProcessingCompleteHandler (job: PgBoss.Job<any>): Promise<void> {
-    const { id, data: { request: { data }, failed, state, createdOn } } = job;
+  async eventProcessingCompleteHandler (job: PgBoss.JobWithMetadata<any>): Promise<void> {
+    const { id, retrycount, data: { request: { data }, failed, state, createdOn } } = job;
 
     if (failed) {
       log(`Job ${id} for queue ${QUEUE_EVENT_PROCESSING} failed`);
@@ -261,16 +271,21 @@ export class EventWatcher {
     }
 
     const { blockHash, publish }: EventsJobData = data;
+    const blockProgress = await this._indexer.getBlockProgress(blockHash);
+    assert(blockProgress);
 
-    // TODO: Check if job was retried and start historical processing
+    // Check if job was retried
+    if (retrycount > 0) {
+      // Reset watcher to remove any data after this block
+      await this._indexer.resetWatcherToBlock(blockProgress.blockNumber);
+      // Start block processing (Try restarting historical processing or continue realtime processing)
+      this.startBlockProcessing();
+    }
 
     // Check if publish is set to true
     // Events and blocks are not published in historical processing
     // GQL subscription events will not be triggered if publish is set to false
     if (publish) {
-      const blockProgress = await this._indexer.getBlockProgress(blockHash);
-      assert(blockProgress);
-
       await this.publishBlockProgressToSubscribers(blockProgress);
 
       const dbEvents = await this._indexer.getBlockEvents(

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -262,6 +262,8 @@ export class EventWatcher {
 
     const { blockHash, publish }: EventsJobData = data;
 
+    // TODO: Check if job was retried and start historical processing
+
     // Check if publish is set to true
     // Events and blocks are not published in historical processing
     // GQL subscription events will not be triggered if publish is set to false

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -14,7 +14,7 @@ interface Config {
   maxCompletionLag: number
 }
 
-type JobCallback = (job: PgBoss.JobWithDoneCallback<any, any>) => Promise<void>;
+type JobCallback = (job: PgBoss.JobWithDoneCallback<any, any> | PgBoss.JobWithMetadataDoneCallback<any, any>) => Promise<void>;
 
 // Default number of jobs fetched from DB per polling interval (newJobCheckInterval)
 const DEFAULT_JOBS_PER_INTERVAL = 5;
@@ -119,6 +119,7 @@ export class JobQueue {
       {
         teamSize: DEFAULT_JOBS_PER_INTERVAL,
         teamConcurrency: 1
+        // TODO: Accept options similar to subscribe method
       },
       async (job: PgBoss.JobWithDoneCallback<any, any>) => {
         try {

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -14,7 +14,7 @@ interface Config {
   maxCompletionLag: number
 }
 
-type JobCallback = (job: PgBoss.JobWithDoneCallback<any, any> | PgBoss.JobWithMetadataDoneCallback<any, any>) => Promise<void>;
+type JobCompleteCallback = (job: PgBoss.Job | PgBoss.JobWithMetadata) => Promise<void>;
 
 // Default number of jobs fetched from DB per polling interval (newJobCheckInterval)
 const DEFAULT_JOBS_PER_INTERVAL = 5;
@@ -91,13 +91,17 @@ export class JobQueue {
     await this._boss.stop();
   }
 
-  async subscribe (queue: string, callback: JobCallback, subscribeOptions: PgBoss.SubscribeOptions = {}): Promise<string> {
+  async subscribe (
+    queue: string,
+    callback: PgBoss.SubscribeHandler<any, any>,
+    options: PgBoss.SubscribeOptions = {}
+  ): Promise<string> {
     return await this._boss.subscribe(
       queue,
       {
         teamSize: DEFAULT_JOBS_PER_INTERVAL,
         teamConcurrency: 1,
-        ...subscribeOptions
+        ...options
       },
       async (job) => {
         try {
@@ -113,13 +117,13 @@ export class JobQueue {
     );
   }
 
-  async onComplete (queue: string, callback: JobCallback): Promise<string> {
+  async onComplete (queue: string, callback: JobCompleteCallback, options: PgBoss.SubscribeOptions = {}): Promise<string> {
     return await this._boss.onComplete(
       queue,
       {
         teamSize: DEFAULT_JOBS_PER_INTERVAL,
-        teamConcurrency: 1
-        // TODO: Accept options similar to subscribe method
+        teamConcurrency: 1,
+        ...options
       },
       async (job: PgBoss.JobWithDoneCallback<any, any>) => {
         try {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -229,6 +229,7 @@ export interface IndexerInterface {
   saveOrUpdateState (state: StateInterface): Promise<StateInterface>
   removeStates (blockNumber: number, kind: StateKind): Promise<void>
   resetWatcherToBlock (blockNumber: number): Promise<void>
+  clearProcessedBlockData (block: BlockProgressInterface): Promise<void>
   getResultEvent (event: EventInterface): any
 }
 
@@ -297,7 +298,6 @@ export enum EventsQueueJobKind {
 export interface EventsJobData {
   kind: EventsQueueJobKind.EVENTS;
   blockHash: string;
-  isRetryAttempt: boolean;
   publish: boolean;
 }
 


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Remove processed data on error in events processing and retry job with exponential backoff
- Restart historical processing after retried job completes successfully
- Set zero hash in sync status table during historical processing to avoid fetching data for last block in batch