### PR TITLE
Fix events queue job retry by resetting watcher in job-runner

### DIFF
--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -243,18 +243,7 @@ export class EventWatcher {
     if (nextBatchStartBlockNumber > this._historicalProcessingEndBlockNumber) {
       // Start next batch of historical processing or realtime processing
       this.startBlockProcessing();
-
-      return;
     }
-
-    // Push job for next batch of blocks
-    await this._jobQueue.pushJob(
-      QUEUE_HISTORICAL_PROCESSING,
-      {
-        blockNumber: nextBatchStartBlockNumber,
-        processingEndBlockNumber: this._historicalProcessingEndBlockNumber
-      }
-    );
   }
 
   async eventProcessingCompleteHandler (job: PgBoss.JobWithMetadata<any>): Promise<void> {

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -20,7 +20,7 @@ type JobCompleteCallback = (job: PgBoss.Job | PgBoss.JobWithMetadata) => Promise
 const DEFAULT_JOBS_PER_INTERVAL = 5;
 
 // Interval time to check for events queue to be empty
-const EMPTY_QUEUE_CHECK_INTERVAL = 5000;
+const EMPTY_QUEUE_CHECK_INTERVAL = 1000;
 
 const log = debug('vulcanize:job-queue');
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -246,6 +246,17 @@ export class JobRunner {
 
     this._historicalProcessingCompletedUpto = endBlock;
 
+    if (endBlock < processingEndBlockNumber) {
+      // If endBlock is lesser than processingEndBlockNumber push new historical job
+      await this.jobQueue.pushJob(
+        QUEUE_HISTORICAL_PROCESSING,
+        {
+          blockNumber: endBlock + 1,
+          processingEndBlockNumber: processingEndBlockNumber
+        }
+      );
+    }
+
     await this.jobQueue.markComplete(
       job,
       { isComplete: true, endBlock }


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Reset watcher in job-runner so that after successful retry of events job, block processing starts from correct block
- Reduce `waitForEmptyQueue` interval time from 5 to 1 sec