### PR TITLE
Fix generated watcher GQL query name and add `_change_block` filter

### DIFF
--- a/packages/codegen/src/resolvers.ts
+++ b/packages/codegen/src/resolvers.ts
@@ -12,6 +12,7 @@ import pluralize from 'pluralize';
 
 import { getGqlForSol, getTsForGql } from './utils/type-mappings';
 import { Param } from './utils/types';
+import { lowerCamelCase } from './utils/helpers';
 
 const TEMPLATE_FILE = './templates/resolvers-template.handlebars';
 
@@ -62,7 +63,7 @@ export class Resolvers {
       }
 
       const entityName = subgraphTypeDef.name.value;
-      const queryName = `${entityName.charAt(0).toLowerCase()}${entityName.slice(1)}`;
+      const queryName = lowerCamelCase(entityName);
 
       let pluralQueryName = pluralize(queryName);
       pluralQueryName = (pluralQueryName === queryName) ? `${pluralQueryName}s` : pluralQueryName;

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -12,7 +12,7 @@ import pluralize from 'pluralize';
 
 import { getGqlForSol } from './utils/type-mappings';
 import { Param } from './utils/types';
-import { getBaseType, isArrayType } from './utils/helpers';
+import { getBaseType, isArrayType, lowerCamelCase } from './utils/helpers';
 
 const OrderDirection = 'OrderDirection';
 const BlockHeight = 'Block_height';
@@ -188,7 +188,7 @@ export class Schema {
       const subgraphType = subgraphTypeDef.name.value;
 
       // Lowercase first letter for query name.
-      const queryName = `${subgraphType.charAt(0).toLowerCase()}${subgraphType.slice(1)}`;
+      const queryName = lowerCamelCase(subgraphType);
 
       const queryObject: { [key: string]: any; } = {};
       queryObject[queryName] = {

--- a/packages/codegen/src/utils/helpers.ts
+++ b/packages/codegen/src/utils/helpers.ts
@@ -64,7 +64,7 @@ export function filterInheritedContractNodes (ast: SourceUnit, contractNodes: AS
  * @param value
  */
 export function lowerCamelCase (value: string): string {
-  const lowerCaseIndex = value.split('').findIndex(char => char.toLocaleLowerCase() === char);
+  const lowerCaseIndex = value.split('').findIndex(char => char.toLowerCase() === char);
 
-  return `${value.slice(0, lowerCaseIndex).toLowerCase()}${value.slice(1)}`;
+  return `${value.slice(0, lowerCaseIndex).toLowerCase()}${value.slice(lowerCaseIndex)}`;
 }

--- a/packages/codegen/src/utils/helpers.ts
+++ b/packages/codegen/src/utils/helpers.ts
@@ -58,3 +58,13 @@ export function filterInheritedContractNodes (ast: SourceUnit, contractNodes: AS
 
   return resultSet;
 }
+
+/**
+ * Convert initial uppercase letters of camel case to lowercase
+ * @param value
+ */
+export function lowerCamelCase (value: string): string {
+  const lowerCaseIndex = value.split('').findIndex(char => char.toLocaleLowerCase() === char);
+
+  return `${value.slice(0, lowerCaseIndex).toLowerCase()}${value.slice(1)}`;
+}


### PR DESCRIPTION
Part of [Update code generator for subgraphs](https://www.notion.so/Update-code-generator-for-subgraphs-f34966742a9f4bdaa8537fbc832b1a95?pvs=23)

- Fix GQL query name generated from entities like:
  - `NFTPosition` -> `nftposition`
  - `DirectPosition` -> `directPosition`
- Add `_change_block` field in where filter
- TODOs to be implemented in follow on PRs:
  -  Add fields to GQL filter input based on entity properties