### PR TITLE
Remove check for blocks count in `eventsInRange` query and check sync status instead

### DIFF
--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -587,7 +587,11 @@ export class Schema {
         latestIndexedBlockHash: 'String!',
         latestIndexedBlockNumber: 'Int!',
         latestCanonicalBlockHash: 'String!',
-        latestCanonicalBlockNumber: 'Int!'
+        latestCanonicalBlockNumber: 'Int!',
+        initialIndexedBlockHash: 'String!',
+        initialIndexedBlockNumber: 'Int!',
+        latestProcessedBlockHash: 'String!',
+        latestProcessedBlockNumber: 'Int!'
       }
     });
 

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -157,9 +157,14 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
         gqlTotalQueryCount.inc(1);
         gqlQueryCount.labels('eventsInRange').inc(1);
 
-        const { expected, actual } = await indexer.getProcessedBlockCountForRange(fromBlockNumber, toBlockNumber);
-        if (expected !== actual) {
-          throw new Error(`Range not available, expected ${expected}, got ${actual} blocks in range`);
+        const syncStatus = await indexer.getSyncStatus();
+
+        if (!syncStatus) {
+          throw new Error('No blocks processed yet');
+        }
+
+        if ((fromBlockNumber < syncStatus.initialIndexedBlockNumber) || (toBlockNumber > syncStatus.latestProcessedBlockNumber)) {
+          throw new Error(`Block range should be between ${syncStatus.initialIndexedBlockNumber} and ${syncStatus.latestProcessedBlockNumber}`);
         }
 
         const events = await indexer.getEventsInRange(fromBlockNumber, toBlockNumber);


### PR DESCRIPTION
Part of [Fix Azimuth Query](https://www.notion.so/Fix-Azimuth-Query-c9e2c6bdfc254bf0bd424173af3f3614)

- Check that query block range is between sync status `initialIndexed` and `latestProcessed` block numbers