### PR TITLE
Add `gqlPath` in config for GQL server URL

### DIFF
--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -2,6 +2,7 @@
   host = "127.0.0.1"
   port = {{port}}
   kind = "{{watcherKind}}"
+  gqlPath = "/graphql"
 
   # Checkpointing state.
   checkpointing = true

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -200,6 +200,7 @@ export interface ServerConfig {
   host: string;
   port: number;
   mode: string;
+  gqlPath: string;
   kind: string;
   enableConfigValidation: boolean;
   checkpointing: boolean;


### PR DESCRIPTION
Part of [Make server path configurable in watcher](https://www.notion.so/Make-server-path-configurable-in-watcher-f7b90d2f94ad4a39ab9baf68b160f49c?pvs=23)