### PR TITLE
Publish events for GQL subscription in historical processing

### DIFF
--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -29,10 +29,8 @@ interface Config {
 }
 
 interface RealtimeBlockCompleteEvent {
-  onRealtimeBlockCompleteEvent: {
-    blockNumber: number;
-    isComplete: boolean;
-  }
+  blockNumber: number;
+  isComplete: boolean;
 }
 
 export class EventWatcher {
@@ -63,7 +61,7 @@ export class EventWatcher {
     return this._pubsub.asyncIterator([BLOCK_PROGRESS_EVENT]);
   }
 
-  getRealtimeBlockCompleteEvent (): AsyncIterator<RealtimeBlockCompleteEvent> {
+  getRealtimeBlockCompleteEvent (): AsyncIterator<{ onRealtimeBlockCompleteEvent: RealtimeBlockCompleteEvent }> {
     return this._pubsub.asyncIterator(REALTIME_BLOCK_COMPLETE_EVENT);
   }
 

--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -63,17 +63,17 @@ export const fillBlocks = async (
 
   // Creating an AsyncIterable from AsyncIterator to iterate over the values.
   // https://www.codementor.io/@tiagolopesferreira/asynchronous-iterators-in-javascript-jl1yg8la1#for-wait-of
-  const blockProgressEventIterable = {
-    // getBlockProgressEventIterator returns an AsyncIterator which can be used to listen to BlockProgress events.
-    [Symbol.asyncIterator]: eventWatcher.getBlockProgressEventIterator.bind(eventWatcher)
+  const realtimeBlockCompleteEventIterable = {
+    // getRealtimeBlockCompleteEvent returns an AsyncIterator which can be used to listen to realtime processing block complete events.
+    [Symbol.asyncIterator]: eventWatcher.getRealtimeBlockCompleteEvent.bind(eventWatcher)
   };
 
   console.time('time:fill#fillBlocks-process_blocks');
 
   // Iterate over async iterable.
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
-  for await (const data of blockProgressEventIterable) {
-    const { onBlockProgressEvent: { blockNumber, isComplete } } = data;
+  for await (const data of realtimeBlockCompleteEventIterable) {
+    const { onRealtimeBlockCompleteEvent: { blockNumber, isComplete } } = data;
 
     if (isComplete) {
       const blocksProcessed = blockNumber - startBlock + 1;

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -302,6 +302,7 @@ export interface EventsJobData {
   kind: EventsQueueJobKind.EVENTS;
   blockHash: string;
   publish: boolean;
+  isRealtimeProcessing: boolean;
 }
 
 export interface ContractJobData {


### PR DESCRIPTION
Part of [How to subscribe to azimuthOnEvent](https://www.notion.so/How-to-subscribe-to-azimuthOnEvent-fa1cd653a42a45ca82cfd4d1e7c35fee)

- Add new pubsub event `realtime-block-complete-event` and use for realtime processing instead of `block-progress-event`