### PR TITLE
Add CLI tool to compare watcher GQL responses

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,3 +54,29 @@ A basic CLI to pass messages between peers using `stdin`/`stdout`
   * `enable-debug-info`: Whether to broadcast node's info over pubsub on request
 
 * The process starts reading from `stdin` and outputs messages from others peers over the `/chat/1.0.0` protocol to `stdout`.
+
+## compare-gql
+
+A basic CLI to to get and compare watcher response.
+
+* Create a `config.yaml` file in the following format in `packages/cli`:
+
+  ```yaml
+  # Is watcher a subgraph watcher
+  isSubgraph: false
+
+  # Watcher URL
+  url: ""
+
+  # Output file path
+  outputFilePath: "src/output.json"
+
+  # Optional parameter to override default GQL query
+  graphqlQuery: ""
+  ```
+
+* Run the following command to get and compare watcher response:
+
+  ```
+  yarn compare-gql --config config.yaml
+  ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -62,21 +62,35 @@ A basic CLI to to get and compare watcher response.
 * Create a `config.yaml` file in the following format in `packages/cli`:
 
   ```yaml
-  # Is watcher a subgraph watcher
-  isSubgraph: false
-
   # Watcher URL
   url: ""
 
-  # Output file path
-  outputFilePath: "src/output.json"
+  # Boolean to specify if it is a subgraph watcher
+  isSubgraph: false
+
+  # File path for saving GQL result
+  gqlResultFilepath: "./result.json"
 
   # Optional parameter to override default GQL query
   graphqlQuery: ""
   ```
 
-* Run the following command to get and compare watcher response:
+* Run the following command to fetch and save first GQL response:
 
   ```
   yarn compare-gql --config config.yaml
   ```
+
+  * On running CLI for the first time
+
+    ```
+      vulcanize:compare-gql Fetching response for the first time, re run CLI to compare with latest GQL response
+    ```
+
+* Re run CLI after some time (average time taken for new block in Ethereum: `~12 seconds`)
+
+  ```
+  yarn compare-gql --config config.yaml
+  ```
+
+* The diff for latest and previous GQL responses is shown

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,7 +57,7 @@ A basic CLI to pass messages between peers using `stdin`/`stdout`
 
 ## compare-gql
 
-A basic CLI to to get and compare watcher response.
+A basic CLI to to fetch and compare watcher GQL response.
 
 * Create a `config.yaml` file in the following format in `packages/cli`:
 

--- a/packages/cli/config.yaml
+++ b/packages/cli/config.yaml
@@ -1,11 +1,12 @@
-# Is watcher a subgraph watcher
-isSubgraph: false
-
 # Watcher URL
 url: ""
 
-# Output file path
-gqlResultFilepath: "src/output.json"
+# Boolean to specify if it is a subgraph watcher
+isSubgraph: false
+
+# File path for saving GQL result
+gqlResultFilepath: "./result.json"
 
 # Optional parameter to override default GQL query
+# Set GQL filepath containing query
 graphqlQuery: ""

--- a/packages/cli/config.yaml
+++ b/packages/cli/config.yaml
@@ -1,0 +1,11 @@
+# Is watcher a subgraph watcher
+isSubgraph: false
+
+# Watcher URL
+url: ""
+
+# Output file path
+gqlResultFilepath: "src/output.json"
+
+# Optional parameter to override default GQL query
+graphqlQuery: ""

--- a/packages/cli/graphql/azimuth-query.graphql
+++ b/packages/cli/graphql/azimuth-query.graphql
@@ -1,0 +1,34 @@
+{
+  azimuthGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  claimsGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  censuresGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  conditionalStarReleaseGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  delegatedSendingGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  eclipticGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  linearStarReleaseGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+  pollsGetSyncStatus {
+    latestProcessedBlockNumber
+    latestIndexedBlockNumber
+  }
+}

--- a/packages/cli/graphql/non-subgraph-query.graphql
+++ b/packages/cli/graphql/non-subgraph-query.graphql
@@ -1,0 +1,12 @@
+{
+  getSyncStatus {
+    initialIndexedBlockHash
+    initialIndexedBlockNumber
+    latestCanonicalBlockHash
+    latestIndexedBlockHash
+    latestCanonicalBlockNumber
+    latestIndexedBlockNumber
+    latestProcessedBlockHash
+    latestProcessedBlockNumber
+  }
+}

--- a/packages/cli/graphql/subgraph-query.graphql
+++ b/packages/cli/graphql/subgraph-query.graphql
@@ -1,0 +1,19 @@
+{
+  getSyncStatus {
+    initialIndexedBlockHash
+    initialIndexedBlockNumber
+    latestCanonicalBlockHash
+    latestIndexedBlockHash
+    latestCanonicalBlockNumber
+    latestIndexedBlockNumber
+    latestProcessedBlockHash
+    latestProcessedBlockNumber
+  }
+  _meta {
+    block {
+      hash
+      number
+      timestamp
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
     "build": "yarn clean && tsc && yarn copy-assets",
     "clean": "rm -rf ./dist",
     "copy-assets": "copyfiles -u 1 src/**/*.gql dist/",
-    "chat": "DEBUG='vulcanize:*, laconic:*' node dist/chat.js"
+    "chat": "DEBUG='vulcanize:*, laconic:*' node dist/chat.js",
+    "compare-gql": "DEBUG='vulcanize:*' node dist/compare-gql.js"
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
@@ -27,7 +28,11 @@
     "debug": "^4.3.1",
     "ethers": "^5.4.4",
     "express": "^4.18.2",
+    "graphql": "^15.5.0",
+    "graphql-request": "^6.1.0",
     "graphql-subscriptions": "^2.0.0",
+    "js-yaml": "^4.0.0",
+    "json-diff": "^0.5.4",
     "lodash": "^4.17.21",
     "pluralize": "^8.0.0",
     "reflect-metadata": "^0.1.13",
@@ -36,6 +41,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.14",
+    "@types/js-yaml": "^4.0.3",
+    "@types/json-diff": "^0.5.2",
     "@types/node": "16.11.7",
     "@types/pluralize": "^0.0.29",
     "@types/yargs": "^17.0.0",

--- a/packages/cli/src/compare-gql.ts
+++ b/packages/cli/src/compare-gql.ts
@@ -7,9 +7,10 @@ import path from 'path';
 import yaml from 'js-yaml';
 import debug from 'debug';
 
-const log = debug('vulcanize:compare-gql');
 const SUBGRAPH_QUERY_FILEPATH = 'graphql/subgraph-query.graphql';
 const NON_SUBGRAPH_QUERY_FILEPATH = 'graphql/non-subgraph-query.graphql';
+
+const log = debug('vulcanize:compare-gql');
 
 function readFromJSONFile (filename: string): {[key: string]: any} | null {
   const fileContents = fs.readFileSync(filename, 'utf-8');
@@ -45,7 +46,7 @@ async function main (): Promise<void> {
   const configFilePath = path.resolve(argv.config);
   const inputConfig = yaml.load(fs.readFileSync(configFilePath, 'utf8')) as any;
 
-  log('Config file:', inputConfig);
+  log('Config:', inputConfig);
 
   const isSubgraph = inputConfig.isSubgraph;
   const watcherUrl = inputConfig.url;
@@ -64,7 +65,7 @@ async function main (): Promise<void> {
   try {
     gqlResponse = await request(watcherUrl, query);
   } catch (err) {
-    throw new Error('Error making GraphQL request:' + (err as Error).message);
+    throw new Error('Error in GQL request: ' + (err as Error).message);
   }
 
   const readOutputData = readFromJSONFile(gqlResultFilepath);
@@ -73,7 +74,7 @@ async function main (): Promise<void> {
     const diff = jsonDiff.diffString(readOutputData, gqlResponse);
 
     if (diff !== '') {
-      log('Showing diff', diff);
+      log('Diff detected', diff);
     } else {
       log('No diff detected, GQL response', gqlResponse);
     }

--- a/packages/cli/src/compare-gql.ts
+++ b/packages/cli/src/compare-gql.ts
@@ -1,0 +1,85 @@
+import { request } from 'graphql-request';
+import * as fs from 'fs';
+import jsonDiff from 'json-diff';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import path from 'path';
+import yaml from 'js-yaml';
+import debug from 'debug';
+
+const log = debug('vulcanize:compare-gql');
+const SUBGRAPH_QUERY_FILEPATH = 'graphql/subgraph-query.graphql';
+const NON_SUBGRAPH_QUERY_FILEPATH = 'graphql/non-subgraph-query.graphql';
+
+function readFromJSONFile (filename: string): any {
+  const fileContents = fs.readFileSync(filename, 'utf-8');
+  if (fileContents !== '') {
+    return JSON.parse(fileContents);
+  }
+}
+
+function getQuery (isSubgraph: boolean, queryFilepath?: string): any {
+  if (queryFilepath) {
+    return fs.readFileSync(path.resolve(queryFilepath), 'utf-8');
+  }
+
+  if (isSubgraph) {
+    return fs.readFileSync(SUBGRAPH_QUERY_FILEPATH, 'utf-8');
+  }
+
+  return fs.readFileSync(NON_SUBGRAPH_QUERY_FILEPATH, 'utf-8');
+}
+
+async function main (): Promise<void> {
+  const argv = await yargs(hideBin(process.argv))
+    .option('config', {
+      alias: 'c',
+      demandOption: true,
+      describe: 'Watcher config file path (yaml)',
+      type: 'string'
+    }).argv;
+
+  const configFilePath = path.resolve(argv.config);
+  const inputConfig = yaml.load(fs.readFileSync(configFilePath, 'utf8')) as any;
+
+  log('Config file:', inputConfig);
+
+  const isSubgraph = inputConfig.isSubgraph;
+  const watcherUrl = inputConfig.url;
+  const gqlResultFilepath = path.resolve(inputConfig.gqlResultFilepath);
+  const graphqlQueryFilepath = inputConfig.graphqlQuery;
+
+  if (!fs.existsSync(gqlResultFilepath)) {
+    fs.writeFileSync(gqlResultFilepath, '', 'utf-8');
+  }
+
+  const query = getQuery(isSubgraph, graphqlQueryFilepath);
+
+  let gqlResponse;
+
+  try {
+    gqlResponse = await request(watcherUrl, query);
+  } catch (err) {
+    throw new Error('Error making GraphQL request:' + (err as Error).message);
+  }
+
+  const readOutputData = readFromJSONFile(gqlResultFilepath);
+
+  if (readOutputData !== '') {
+    const diff = jsonDiff.diffString(readOutputData, gqlResponse);
+
+    if (diff !== '') {
+      log('Showing diff', diff);
+    } else {
+      log('No diff detected, GQL response', gqlResponse);
+    }
+  } else {
+    log('No diff detected, GQL response', gqlResponse);
+  }
+
+  fs.writeFileSync(gqlResultFilepath, JSON.stringify(gqlResponse, null, 2));
+}
+
+main().catch(err => {
+  log(err);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,7 +1226,7 @@
     "@graphql-typed-document-node/core" "^3.1.1"
     tslib "^2.4.0"
 
-"@graphql-typed-document-node/core@^3.1.1":
+"@graphql-typed-document-node/core@^3.1.1", "@graphql-typed-document-node/core@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
@@ -6512,6 +6512,13 @@ cross-fetch@^3.1.4:
   dependencies:
     node-fetch "2.6.7"
 
+cross-fetch@^3.1.5:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
@@ -9020,6 +9027,14 @@ graphql-compose@^9.0.3:
   integrity sha512-UsVoxfi2+c8WbHl2pEB+teoRRZoY4mbWBoijeLDGpAZBSPChnqtSRjp+T9UcouLCwGr5ooNyOQLoI3OVzU1bPQ==
   dependencies:
     graphql-type-json "0.3.2"
+
+graphql-request@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-6.1.0.tgz#f4eb2107967af3c7a5907eb3131c671eac89be4f"
+  integrity sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.2.0"
+    cross-fetch "^3.1.5"
 
 graphql-subscriptions@^2.0.0:
   version "2.0.0"
@@ -12222,6 +12237,13 @@ node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@~1.7.1:
   version "1.7.3"


### PR DESCRIPTION
Part of [Update azimuth watcher stack to run in active mode](https://www.notion.so/Update-azimuth-watcher-stack-to-run-in-active-mode-4b4f86ab3ab54943b216af37ac4fb50d)

-  Add CLI `compare-gql`
- Compare GQL queries `getSyncStatus` and `_meta`