### PR TITLE
Fix block processing during chain reorg

### DIFF
--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -871,6 +871,6 @@ export class Indexer implements IndexerInterface {
   }
 
   async getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]> {
-    return this._baseIndexer.getFullTransactions(txHashList)
+    return this._baseIndexer.getFullTransactions(txHashList);
   }
 }

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -869,4 +869,8 @@ export class Indexer implements IndexerInterface {
       await dbTx.release();
     }
   }
+
+  async getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]> {
+    return this._baseIndexer.getFullTransactions(txHashList)
+  }
 }

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -334,4 +334,8 @@ export class Indexer implements IndexerInterface {
   async processStateCheckpoint (contractAddress: string, blockHash: string): Promise<boolean> {
     return false;
   }
+
+  async getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]> {
+    return [];
+  }
 }

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -530,11 +530,15 @@ export class Indexer {
   }
 
   async _fetchTxsFromLogs (logs: any[]): Promise<EthFullTransaction[]> {
-    const txHashes = Array.from([
+    const txHashList = Array.from([
       ...new Set<string>(logs.map((log) => log.transaction.hash))
     ]);
 
-    const ethFullTxPromises = txHashes.map(async txHash => {
+    return this.getFullTransactions(txHashList);
+  }
+
+  async getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]> {
+    const ethFullTxPromises = txHashList.map(async txHash => {
       return this._ethClient.getFullTransaction(txHash);
     });
 

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -233,7 +233,7 @@ export interface IndexerInterface {
   resetWatcherToBlock (blockNumber: number): Promise<void>
   clearProcessedBlockData (block: BlockProgressInterface): Promise<void>
   getResultEvent (event: EventInterface): any
-  getFullTransactions (txHashList: string[]): EthFullTransaction[]
+  getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]>
 }
 
 export interface DatabaseInterface {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -233,6 +233,7 @@ export interface IndexerInterface {
   resetWatcherToBlock (blockNumber: number): Promise<void>
   clearProcessedBlockData (block: BlockProgressInterface): Promise<void>
   getResultEvent (event: EventInterface): any
+  getFullTransactions (txHashList: string[]): EthFullTransaction[]
 }
 
 export interface DatabaseInterface {


### PR DESCRIPTION
Part of [Debug watchers getting stuck intermittently](https://www.notion.so/Debug-watchers-getting-stuck-intermittently-bfb0afa6478141f198f4681c1baf89fd)

- Extra block data was not being fetched when block already saved to DB
  - Always fetch extra block data before block processing job
- Fetch transactions and set to blockAndEvents map when block already saved to DB