### PR TITLE
Handle pruning of non-canonical blocks in case null block is encountered

### DIFF
--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -324,8 +324,8 @@ export class Database implements DatabaseInterface {
     await this._baseDatabase.deleteEntitiesByConditions(queryRunner, entity, findConditions);
   }
 
-  async getAncestorAtDepth (blockHash: string, depth: number): Promise<string> {
-    return this._baseDatabase.getAncestorAtDepth(blockHash, depth);
+  async getAncestorAtHeight (blockHash: string, height: number): Promise<string> {
+    return this._baseDatabase.getAncestorAtHeight(blockHash, height);
   }
 
   _getPropertyColumnMapForEntity (entityName: string): Map<string, string> {

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -744,8 +744,8 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.updateBlockProgress(block, lastProcessedEventIndex);
   }
 
-  async getAncestorAtDepth (blockHash: string, depth: number): Promise<string> {
-    return this._baseIndexer.getAncestorAtDepth(blockHash, depth);
+  async getAncestorAtHeight (blockHash: string, height: number): Promise<string> {
+    return this._baseIndexer.getAncestorAtHeight(blockHash, height);
   }
 
   async resetWatcherToBlock (blockNumber: number): Promise<void> {

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -107,9 +107,9 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
-  async getAncestorAtDepth (blockHash: string, depth: number): Promise<string> {
+  async getAncestorAtHeight (blockHash: string, height: number): Promise<string> {
     assert(blockHash);
-    assert(depth);
+    assert(height);
 
     return '';
   }

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -709,8 +709,8 @@ export class Indexer {
     }
   }
 
-  async getAncestorAtDepth (blockHash: string, depth: number): Promise<string> {
-    return this._db.getAncestorAtDepth(blockHash, depth);
+  async getAncestorAtHeight (blockHash: string, height: number): Promise<string> {
+    return this._db.getAncestorAtHeight(blockHash, height);
   }
 
   async saveEventEntity (dbEvent: EventInterface): Promise<EventInterface> {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -173,7 +173,7 @@ export interface IndexerInterface {
   getLatestCanonicalBlock (): Promise<BlockProgressInterface | undefined>
   getLatestStateIndexedBlock (): Promise<BlockProgressInterface>
   getBlockEvents (blockHash: string, where: Where, queryOptions: QueryOptions): Promise<Array<EventInterface>>
-  getAncestorAtDepth (blockHash: string, depth: number): Promise<string>
+  getAncestorAtHeight (blockHash: string, height: number): Promise<string>
   saveBlockAndFetchEvents (block: DeepPartial<BlockProgressInterface>): Promise<[
     BlockProgressInterface,
     DeepPartial<EventInterface>[],
@@ -248,7 +248,7 @@ export interface DatabaseInterface {
   getBlockEvents (blockHash: string, where?: Where, queryOptions?: QueryOptions): Promise<EventInterface[]>;
   getEvent (id: string): Promise<EventInterface | undefined>
   getSyncStatus (queryRunner: QueryRunner): Promise<SyncStatusInterface | undefined>
-  getAncestorAtDepth (blockHash: string, depth: number): Promise<string>
+  getAncestorAtHeight (blockHash: string, height: number): Promise<string>
   getProcessedBlockCountForRange (fromBlockNumber: number, toBlockNumber: number): Promise<{ expected: number, actual: number }>;
   getEventsInRange (fromBlockNumber: number, toBlockNumber: number): Promise<Array<EventInterface>>;
   markBlocksAsPruned (queryRunner: QueryRunner, blocks: BlockProgressInterface[]): Promise<void>;


### PR DESCRIPTION
Part of [Debug watchers getting stuck intermittently](https://www.notion.so/Debug-watchers-getting-stuck-intermittently-bfb0afa6478141f198f4681c1baf89fd)

- Change method to get ancestor at height instead of depth to avoid issues with null block