### PR TITLE
Fix for generating nested filters and loading subgraph entities from db

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.81",
+  "version": "0.2.82",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.81",
-    "@cerc-io/ipld-eth-client": "^0.2.81",
+    "@cerc-io/cache": "^0.2.82",
+    "@cerc-io/ipld-eth-client": "^0.2.82",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.81",
-    "@cerc-io/rpc-eth-client": "^0.2.81",
-    "@cerc-io/util": "^0.2.81",
+    "@cerc-io/peer": "^0.2.82",
+    "@cerc-io/rpc-eth-client": "^0.2.82",
+    "@cerc-io/util": "^0.2.82",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.81",
+    "@cerc-io/util": "^0.2.82",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -4,7 +4,7 @@
 
 import assert from 'assert';
 import { GraphQLSchema, parse, printSchema, print, GraphQLDirective, GraphQLInt, GraphQLBoolean, GraphQLEnumType, DefinitionNode, GraphQLString, GraphQLNonNull } from 'graphql';
-import { ObjectTypeComposer, NonNullComposer, ObjectTypeComposerDefinition, ObjectTypeComposerFieldConfigMapDefinition, SchemaComposer, ListComposer, ComposeOutputType } from 'graphql-compose';
+import { ObjectTypeComposer, NonNullComposer, ObjectTypeComposerDefinition, ObjectTypeComposerFieldConfigMapDefinition, SchemaComposer, ListComposer, ComposeOutputType, ThunkComposer } from 'graphql-compose';
 import { Writable } from 'stream';
 import { utils } from 'ethers';
 import { VariableDeclaration } from '@solidity-parser/parser/dist/src/ast-types';
@@ -346,6 +346,11 @@ export class Schema {
       ({ type, isRelation, entityType } = this._getDetailsForSubgraphField(childFieldType));
 
       isArray = true;
+    }
+
+    if (fieldType instanceof ThunkComposer) {
+      const unwrappedFieldType = fieldType.getUnwrappedTC() as ObjectTypeComposer;
+      ({ type, isRelation, entityType } = this._getDetailsForSubgraphField(unwrappedFieldType));
     }
 
     if (fieldType instanceof ObjectTypeComposer) {

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.81",
-    "@cerc-io/ipld-eth-client": "^0.2.81",
-    "@cerc-io/solidity-mapper": "^0.2.81",
-    "@cerc-io/util": "^0.2.81",
+    "@cerc-io/cli": "^0.2.82",
+    "@cerc-io/ipld-eth-client": "^0.2.82",
+    "@cerc-io/solidity-mapper": "^0.2.82",
+    "@cerc-io/util": "^0.2.82",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.81",
+    "@cerc-io/graph-node": "^0.2.82",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.81",
+    "@cerc-io/solidity-mapper": "^0.2.82",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.81",
-    "@cerc-io/ipld-eth-client": "^0.2.81",
-    "@cerc-io/util": "^0.2.81",
+    "@cerc-io/cache": "^0.2.82",
+    "@cerc-io/ipld-eth-client": "^0.2.82",
+    "@cerc-io/util": "^0.2.82",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/graph-node/src/loader.ts
+++ b/packages/graph-node/src/loader.ts
@@ -86,10 +86,7 @@ export const instantiate = async (
         assert(indexer.getEntityTypesMap);
         const entityTypesMap = indexer.getEntityTypesMap();
 
-        const entityTypes = entityTypesMap.get(entityName);
-        assert(entityTypes);
-
-        return database.toGraphEntity(instanceExports, entityName, entityData, entityTypes);
+        return database.toGraphEntity(instanceExports, entityName, entityData, entityTypesMap);
       },
       'store.set': async (entity: number, id: number, data: number) => {
         const entityName = __getString(entity);

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.81",
-    "@cerc-io/util": "^0.2.81",
+    "@cerc-io/cache": "^0.2.82",
+    "@cerc-io/util": "^0.2.82",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.81",
-    "@cerc-io/ipld-eth-client": "^0.2.81",
-    "@cerc-io/util": "^0.2.81",
+    "@cerc-io/cache": "^0.2.82",
+    "@cerc-io/ipld-eth-client": "^0.2.82",
+    "@cerc-io/util": "^0.2.82",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.81",
-    "@cerc-io/solidity-mapper": "^0.2.81",
+    "@cerc-io/peer": "^0.2.82",
+    "@cerc-io/solidity-mapper": "^0.2.82",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -52,7 +52,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.81",
+    "@cerc-io/cache": "^0.2.82",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/graph/database.ts
+++ b/packages/util/src/graph/database.ts
@@ -878,7 +878,10 @@ export class GraphDatabase {
     // Avoid loading relation if selections only has id field.
     if (childSelections.length === 1 && childSelections[0].kind === 'Field' && childSelections[0].name.value === 'id') {
       entities.forEach((entity: any) => {
-        entity[field] = { id: entity[field] };
+        // Set only if field value is not null
+        if (entity[field]) {
+          entity[field] = { id: entity[field] };
+        }
       });
 
       return;


### PR DESCRIPTION
Part of https://www.notion.so/Run-ajna-finance-subgraph-watcher-87748d78cd7a471b8d71f50d5fdc2657?pvs=23

- Handle `ThunkComposer` graphql-compose field types when generating nested filters for plural subgraph queries
- When loading a subgraph entity from db on a `store.get` API call, for relational fields, use graph value kind for `id` field in the related enitity
  (Earlier, always `String` kind was used, which would result in errors if the mapping code is expecting something else like `Bytes`) 