### PR TITLE
Fetch logs filtered by block number instead of block hash for FEVM

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.83",
+  "version": "0.2.84",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.83",
-    "@cerc-io/ipld-eth-client": "^0.2.83",
+    "@cerc-io/cache": "^0.2.84",
+    "@cerc-io/ipld-eth-client": "^0.2.84",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.83",
-    "@cerc-io/rpc-eth-client": "^0.2.83",
-    "@cerc-io/util": "^0.2.83",
+    "@cerc-io/peer": "^0.2.84",
+    "@cerc-io/rpc-eth-client": "^0.2.84",
+    "@cerc-io/util": "^0.2.84",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.83",
+    "@cerc-io/util": "^0.2.84",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.83",
-    "@cerc-io/ipld-eth-client": "^0.2.83",
-    "@cerc-io/solidity-mapper": "^0.2.83",
-    "@cerc-io/util": "^0.2.83",
+    "@cerc-io/cli": "^0.2.84",
+    "@cerc-io/ipld-eth-client": "^0.2.84",
+    "@cerc-io/solidity-mapper": "^0.2.84",
+    "@cerc-io/util": "^0.2.84",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.83",
+    "@cerc-io/graph-node": "^0.2.84",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.83",
+    "@cerc-io/solidity-mapper": "^0.2.84",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.83",
-    "@cerc-io/ipld-eth-client": "^0.2.83",
-    "@cerc-io/util": "^0.2.83",
+    "@cerc-io/cache": "^0.2.84",
+    "@cerc-io/ipld-eth-client": "^0.2.84",
+    "@cerc-io/util": "^0.2.84",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.83",
-    "@cerc-io/util": "^0.2.83",
+    "@cerc-io/cache": "^0.2.84",
+    "@cerc-io/util": "^0.2.84",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.83",
-    "@cerc-io/ipld-eth-client": "^0.2.83",
-    "@cerc-io/util": "^0.2.83",
+    "@cerc-io/cache": "^0.2.84",
+    "@cerc-io/ipld-eth-client": "^0.2.84",
+    "@cerc-io/util": "^0.2.84",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.83",
-    "@cerc-io/solidity-mapper": "^0.2.83",
+    "@cerc-io/peer": "^0.2.84",
+    "@cerc-io/solidity-mapper": "^0.2.84",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -52,7 +52,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.83",
+    "@cerc-io/cache": "^0.2.84",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -526,12 +526,28 @@ export class Indexer {
   }
 
   async _fetchLogsAndTransactions (blockHash: string, blockNumber: number, addresses?: string[], topics?: string[][]): Promise<{ logs: any[]; transactions: EthFullTransaction[] }> {
-    const { logs } = await this._ethClient.getLogs({
-      blockHash,
-      blockNumber: blockNumber.toString(),
-      addresses,
-      topics
-    });
+    let logs: any[] = [];
+
+    // Get logs by block number filter in case of FEVM as block hash filter takes a long time
+    if (this._upstreamConfig.ethServer.isFEVM) {
+      assert(this._ethClient.getLogsForBlockRange, 'getLogsForBlockRange() not implemented in ethClient');
+
+      ({ logs } = await this._ethClient.getLogsForBlockRange({
+        fromBlock: blockNumber,
+        toBlock: blockNumber,
+        addresses,
+        topics
+      }));
+
+      logs = logs.filter(log => log.blockHash === blockHash);
+    } else {
+      ({ logs } = await this._ethClient.getLogs({
+        blockHash,
+        blockNumber: blockNumber.toString(),
+        addresses,
+        topics
+      }));
+    }
 
     const transactions = await this._fetchTxsFromLogs(logs);
 


### PR DESCRIPTION
Part of [Investigate subgraph watchers lagging behind head](https://www.notion.so/Investigate-subgraph-watchers-lagging-behind-head-01b72294ca8e4f658e4c0e86b36d19e2)

- Fetch logs by block number if upstream eth server is FEVM
  - In realtime sync, fetching logs by block hash has started taking longer time ~1min
  - Fetching logs by block number takes ~10sec
- Use `node-fetch` instead of `ethersjs` for `eth_getLogs` RPC method to fetch logs
  - `ethersjs` is taking longer time for `eth_getLogs` requests ~50sec