### PR TITLE
Implement failover for RPC endpoints in watcher

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.85",
+  "version": "0.2.86",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.85",
-    "@cerc-io/ipld-eth-client": "^0.2.85",
+    "@cerc-io/cache": "^0.2.86",
+    "@cerc-io/ipld-eth-client": "^0.2.86",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.85",
-    "@cerc-io/rpc-eth-client": "^0.2.85",
-    "@cerc-io/util": "^0.2.85",
+    "@cerc-io/peer": "^0.2.86",
+    "@cerc-io/rpc-eth-client": "^0.2.86",
+    "@cerc-io/util": "^0.2.86",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.85",
+    "@cerc-io/util": "^0.2.86",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -63,7 +63,9 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    rpcProviderEndpoints = [
+      "http://127.0.0.1:8081"
+    ]
 
     # Boolean flag to specify if rpc-eth-client should be used for RPC endpoint instead of ipld-eth-client (ipld-eth-server GQL client)
     rpcClient = false
@@ -100,3 +102,6 @@
   # Max block range of historical processing after which it waits for completion of events processing
   # If set to -1 historical processing does not wait for events processing and completes till latest canonical block
   historicalMaxFetchAhead = 10000
+
+  # Max number of retries to fetch new block after which watcher will failover to other RPC endpoints
+  maxNewBlockRetries = 3

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -199,12 +199,12 @@ export class Indexer implements IndexerInterface {
     await this._baseIndexer.fetchStateStatus();
   }
 
-  doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: BaseProvider }): void {
+  switchClients ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: BaseProvider }): void {
     this._ethClient = ethClient;
     this._ethProvider = ethProvider;
-    this._baseIndexer.doFailOverEndpoints({ ethClient, ethProvider });
+    this._baseIndexer.switchClients({ ethClient, ethProvider });
     {{#if (subgraphPath)}}
-    this._graphWatcher.doFailOverEndpoints({ ethClient, ethProvider });
+    this._graphWatcher.switchClients({ ethClient, ethProvider });
     {{/if}}
   }
 

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -199,6 +199,15 @@ export class Indexer implements IndexerInterface {
     await this._baseIndexer.fetchStateStatus();
   }
 
+  doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: BaseProvider }): void {
+    this._ethClient = ethClient;
+    this._ethProvider = ethProvider;
+    this._baseIndexer.doFailOverEndpoints({ ethClient, ethProvider });
+    {{#if (subgraphPath)}}
+    this._graphWatcher.doFailOverEndpoints({ ethClient, ethProvider });
+    {{/if}}
+  }
+
   {{#if (subgraphPath)}}
   async getMetaData (block: BlockHeight): Promise<ResultMeta | null> {
     return this._baseIndexer.getMetaData(block);

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.85",
-    "@cerc-io/ipld-eth-client": "^0.2.85",
-    "@cerc-io/solidity-mapper": "^0.2.85",
-    "@cerc-io/util": "^0.2.85",
+    "@cerc-io/cli": "^0.2.86",
+    "@cerc-io/ipld-eth-client": "^0.2.86",
+    "@cerc-io/solidity-mapper": "^0.2.86",
+    "@cerc-io/util": "^0.2.86",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.85",
+    "@cerc-io/graph-node": "^0.2.86",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.85",
+    "@cerc-io/solidity-mapper": "^0.2.86",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.85",
-    "@cerc-io/ipld-eth-client": "^0.2.85",
-    "@cerc-io/util": "^0.2.85",
+    "@cerc-io/cache": "^0.2.86",
+    "@cerc-io/ipld-eth-client": "^0.2.86",
+    "@cerc-io/util": "^0.2.86",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -129,7 +129,7 @@ export class GraphWatcher {
     this.fillEventSignatureMap();
   }
 
-  async doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: providers.BaseProvider }) {
+  async switchClients ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: providers.BaseProvider }) {
     this._ethClient = ethClient;
     this._ethProvider = ethProvider;
   }

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -129,6 +129,11 @@ export class GraphWatcher {
     this.fillEventSignatureMap();
   }
 
+  async doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: providers.BaseProvider }) {
+    this._ethClient = ethClient;
+    this._ethProvider = ethProvider;
+  }
+
   fillEventSignatureMap () {
     this._dataSources.forEach(contract => {
       if (contract.kind === 'ethereum/contract' && contract.mapping.kind === 'ethereum/events') {

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -2,6 +2,7 @@
 
 import assert from 'assert';
 import { DeepPartial, FindConditions, FindManyOptions } from 'typeorm';
+import { providers } from 'ethers';
 
 import {
   IndexerInterface,
@@ -337,5 +338,9 @@ export class Indexer implements IndexerInterface {
 
   async getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]> {
     return [];
+  }
+
+  doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: providers.BaseProvider }): void {
+    return undefined;
   }
 }

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -340,7 +340,7 @@ export class Indexer implements IndexerInterface {
     return [];
   }
 
-  doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: providers.BaseProvider }): void {
+  switchClients ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: providers.BaseProvider }): void {
     return undefined;
   }
 }

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.85",
-    "@cerc-io/util": "^0.2.85",
+    "@cerc-io/cache": "^0.2.86",
+    "@cerc-io/util": "^0.2.86",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.85",
-    "@cerc-io/ipld-eth-client": "^0.2.85",
-    "@cerc-io/util": "^0.2.85",
+    "@cerc-io/cache": "^0.2.86",
+    "@cerc-io/ipld-eth-client": "^0.2.86",
+    "@cerc-io/util": "^0.2.86",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.85",
-    "@cerc-io/solidity-mapper": "^0.2.85",
+    "@cerc-io/peer": "^0.2.86",
+    "@cerc-io/solidity-mapper": "^0.2.86",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -52,7 +52,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.85",
+    "@cerc-io/cache": "^0.2.86",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -79,6 +79,8 @@ export const fetchBlocksAtHeight = async (
       continue;
     }
 
+    // TODO: Configure max retries for new block
+
     // Fitler null blocks
     blocks = ethFullBlocks.filter(block => Boolean(block)) as EthFullBlock[];
 

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -22,15 +22,19 @@ export interface JobQueueConfig {
   lazyUpdateBlockProgress?: boolean;
   subgraphEventsOrder: boolean;
   blockDelayInMilliSecs: number;
+
   // Block range in which logs are fetched during historical blocks processing
   historicalLogsBlockRange?: number;
+
   // Max block range of historical processing after which it waits for completion of events processing
   // If set to -1 historical processing does not wait for events processing and completes till latest canonical block
   historicalMaxFetchAhead?: number;
+
   // Boolean to switch between modes of processing events when starting the server
   // Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
   // Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
   useBlockRanges: boolean;
+
   // Max number of retries to fetch new block after which watcher will failover to other RPC endpoints
   // Infinitely retry if not set
   maxNewBlockRetries?: number;
@@ -259,14 +263,19 @@ export interface UpstreamConfig {
     gqlApiEndpoint: string;
     rpcProviderEndpoints: string[];
     rpcProviderMutationEndpoint: string;
+
     // Boolean flag to specify if rpc-eth-client should be used for RPC endpoint instead of ipld-eth-client (ipld-eth-server GQL client)
     rpcClient: boolean;
+
     // Boolean flag to specify if rpcProviderEndpoint is an FEVM RPC endpoint
     isFEVM: boolean;
+
     // Boolean flag to filter event logs by contracts
     filterLogsByAddresses: boolean;
+
     // Boolean flag to filter event logs by topics
     filterLogsByTopics: boolean;
+
     payments: EthServerPaymentsConfig;
   }
   traceProviderEndpoint: string;

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -254,7 +254,7 @@ export interface UpstreamConfig {
   cache: CacheConfig;
   ethServer: {
     gqlApiEndpoint: string;
-    rpcProviderEndpoint: string;
+    rpcProviderEndpoints: string[];
     rpcProviderMutationEndpoint: string;
     // Boolean flag to specify if rpc-eth-client should be used for RPC endpoint instead of ipld-eth-client (ipld-eth-server GQL client)
     rpcClient: boolean;

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -31,6 +31,9 @@ export interface JobQueueConfig {
   // Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
   // Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
   useBlockRanges: boolean;
+  // Max number of retries to fetch new block after which watcher will failover to other RPC endpoints
+  // Infinitely retry if not set
+  maxNewBlockRetries?: number;
 }
 
 export interface GQLCacheConfig {

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -138,7 +138,7 @@ export class Indexer {
     this._getStorageAt = this._ethClient.getStorageAt.bind(this._ethClient);
   }
 
-  doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: ethers.providers.BaseProvider }): void {
+  switchClients ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: ethers.providers.BaseProvider }): void {
     this._ethClient = ethClient;
     this._ethProvider = ethProvider;
   }

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -138,6 +138,11 @@ export class Indexer {
     this._getStorageAt = this._ethClient.getStorageAt.bind(this._ethClient);
   }
 
+  doFailOverEndpoints ({ ethClient, ethProvider }: { ethClient: EthClient, ethProvider: ethers.providers.BaseProvider }): void {
+    this._ethClient = ethClient;
+    this._ethProvider = ethProvider;
+  }
+
   async fetchContracts (): Promise<void> {
     assert(this._db.getContracts);
 

--- a/packages/util/src/metrics.ts
+++ b/packages/util/src/metrics.ts
@@ -98,7 +98,7 @@ isSyncingHistoricalBlocks.set(Number(undefined));
 // Export metrics on a server
 const app: Application = express();
 
-export const startMetricsServer = async (config: Config, indexer: IndexerInterface): Promise<void> => {
+export const startMetricsServer = async (config: Config, indexer: IndexerInterface, endpointIndexes = { rpcProviderEndpoint: 0 }): Promise<void> => {
   if (!config.metrics) {
     log('Metrics is disabled. To enable add metrics host and port.');
     return;
@@ -128,7 +128,7 @@ export const startMetricsServer = async (config: Config, indexer: IndexerInterfa
 
   await registerDBSizeMetrics(config);
 
-  await registerUpstreamChainHeadMetrics(config);
+  await registerUpstreamChainHeadMetrics(config, endpointIndexes.rpcProviderEndpoint);
 
   // Collect default metrics
   client.collectDefaultMetrics();
@@ -179,8 +179,8 @@ const registerDBSizeMetrics = async ({ database, jobQueue }: Config): Promise<vo
   });
 };
 
-const registerUpstreamChainHeadMetrics = async ({ upstream }: Config): Promise<void> => {
-  const ethRpcProvider = new JsonRpcProvider(upstream.ethServer.rpcProviderEndpoint);
+const registerUpstreamChainHeadMetrics = async ({ upstream }: Config, rpcProviderEndpointIndex: number): Promise<void> => {
+  const ethRpcProvider = new JsonRpcProvider(upstream.ethServer.rpcProviderEndpoints[rpcProviderEndpointIndex]);
 
   // eslint-disable-next-line no-new
   new client.Gauge({

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -3,7 +3,7 @@
 //
 
 import { Connection, DeepPartial, EntityTarget, FindConditions, FindManyOptions, ObjectLiteral, QueryRunner } from 'typeorm';
-import { Transaction } from 'ethers';
+import { Transaction, providers } from 'ethers';
 
 import { MappingKey, StorageLayout } from '@cerc-io/solidity-mapper';
 
@@ -161,6 +161,8 @@ export interface IndexerInterface {
   readonly serverConfig: ServerConfig
   readonly upstreamConfig: UpstreamConfig
   readonly storageLayoutMap: Map<string, StorageLayout>
+  // eslint-disable-next-line no-use-before-define
+  readonly graphWatcher?: GraphWatcherInterface
   init (): Promise<void>
   getBlockProgress (blockHash: string): Promise<BlockProgressInterface | undefined>
   getBlockProgressEntities (where: FindConditions<BlockProgressInterface>, options: FindManyOptions<BlockProgressInterface>): Promise<BlockProgressInterface[]>
@@ -234,6 +236,7 @@ export interface IndexerInterface {
   clearProcessedBlockData (block: BlockProgressInterface): Promise<void>
   getResultEvent (event: EventInterface): any
   getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]>
+  doFailOverEndpoints (clients: { ethClient: EthClient, ethProvider: providers.BaseProvider }): void
 }
 
 export interface DatabaseInterface {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -236,7 +236,7 @@ export interface IndexerInterface {
   clearProcessedBlockData (block: BlockProgressInterface): Promise<void>
   getResultEvent (event: EventInterface): any
   getFullTransactions (txHashList: string[]): Promise<EthFullTransaction[]>
-  doFailOverEndpoints (clients: { ethClient: EthClient, ethProvider: providers.BaseProvider }): void
+  switchClients (clients: { ethClient: EthClient, ethProvider: providers.BaseProvider }): void
 }
 
 export interface DatabaseInterface {


### PR DESCRIPTION
Part of [Ability to configure watchers with multiple RPC endpoints](https://www.notion.so/Ability-to-configure-watchers-with-multiple-RPC-endpoints-dc8d3ff4d647404ab718dfd5a4c9035c)

- Switch endpoint on RPC server errors in job-runner process
- Add config `maxNewBlockRetries` for switching to failover endpoint if new block is not available after max retries
- Handle unknown events removal in historical processing