### PR TITLE
Fetch job queue counts for metrics on scraping

### DIFF
--- a/packages/cli/src/job-runner.ts
+++ b/packages/cli/src/job-runner.ts
@@ -154,7 +154,7 @@ export class JobRunnerCmd {
     await startJobRunner(jobRunner);
     jobRunner.handleShutdown();
 
-    await startMetricsServer(config, indexer, this._currentEndpointIndex);
+    await startMetricsServer(config, jobQueue, indexer, this._currentEndpointIndex);
   }
 
   _getArgv (): any {


### PR DESCRIPTION
Part of [Regenerate ajna watcher with updated subgraph config](https://www.notion.so/Regenerate-ajna-watcher-with-updated-subgraph-config-c9bbecb033024c13a7515c7f1efc3363)

- The `monitor-states` event from `PgBoss` instance gets fired once on starting the server / job-runner, but doesn't get fired subsequently every `monitorStateIntervalSeconds` as expected ([docs](https://github.com/timgit/pg-boss/blob/6.2.2/docs/usage.md#monitor-states))
- Fetch the metrics directly using PgBoss `countStates()` method on every scrape