### PR TITLE
Support fragments in GQL queries for subgraph watchers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.88",
+  "version": "0.2.89",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.88",
-    "@cerc-io/ipld-eth-client": "^0.2.88",
+    "@cerc-io/cache": "^0.2.89",
+    "@cerc-io/ipld-eth-client": "^0.2.89",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.88",
-    "@cerc-io/rpc-eth-client": "^0.2.88",
-    "@cerc-io/util": "^0.2.88",
+    "@cerc-io/peer": "^0.2.89",
+    "@cerc-io/rpc-eth-client": "^0.2.89",
+    "@cerc-io/util": "^0.2.89",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.88",
+    "@cerc-io/util": "^0.2.89",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -10,7 +10,7 @@ import JSONbig from 'json-bigint';
 {{/if}}
 import { ethers, constants } from 'ethers';
 {{#if (subgraphPath)}}
-import { SelectionNode } from 'graphql';
+import { GraphQLResolveInfo } from 'graphql';
 {{/if}}
 
 import { JsonFragment } from '@ethersproject/abi';
@@ -458,9 +458,9 @@ export class Indexer implements IndexerInterface {
     entity: new () => Entity,
     id: string,
     block: BlockHeight,
-    selections: ReadonlyArray<SelectionNode> = []
+    queryInfo: GraphQLResolveInfo
   ): Promise<any> {
-    const data = await this._graphWatcher.getEntity(entity, id, this._relationsMap, block, selections);
+    const data = await this._graphWatcher.getEntity(entity, id, this._relationsMap, block, queryInfo);
 
     return data;
   }
@@ -470,9 +470,9 @@ export class Indexer implements IndexerInterface {
     block: BlockHeight,
     where: { [key: string]: any } = {},
     queryOptions: QueryOptions = {},
-    selections: ReadonlyArray<SelectionNode> = []
+    queryInfo: GraphQLResolveInfo
   ): Promise<any[]> {
-    return this._graphWatcher.getEntities(entity, this._relationsMap, block, where, queryOptions, selections);
+    return this._graphWatcher.getEntities(entity, this._relationsMap, block, where, queryOptions, queryInfo);
   }
 
   {{/if}}

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.88",
-    "@cerc-io/ipld-eth-client": "^0.2.88",
-    "@cerc-io/solidity-mapper": "^0.2.88",
-    "@cerc-io/util": "^0.2.88",
+    "@cerc-io/cli": "^0.2.89",
+    "@cerc-io/ipld-eth-client": "^0.2.89",
+    "@cerc-io/solidity-mapper": "^0.2.89",
+    "@cerc-io/util": "^0.2.89",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.88",
+    "@cerc-io/graph-node": "^0.2.89",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -106,12 +106,11 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
         log('{{this.queryName}}', id, JSON.stringify(block, jsonBigIntStringReplacer));
         gqlTotalQueryCount.inc(1);
         gqlQueryCount.labels('{{this.queryName}}').inc(1);
-        assert(info.fieldNodes[0].selectionSet);
 
         // Set cache-control hints
         // setGQLCacheHints(info, block, gqlCacheConfig);
 
-        return indexer.getSubgraphEntity({{this.entityName}}, id, block, info.fieldNodes[0].selectionSet.selections);
+        return indexer.getSubgraphEntity({{this.entityName}}, id, block, info);
       },
 
       {{this.pluralQueryName}}: async (
@@ -123,7 +122,6 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
         log('{{this.pluralQueryName}}', JSON.stringify(block, jsonBigIntStringReplacer), JSON.stringify(where, jsonBigIntStringReplacer), first, skip, orderBy, orderDirection);
         gqlTotalQueryCount.inc(1);
         gqlQueryCount.labels('{{this.pluralQueryName}}').inc(1);
-        assert(info.fieldNodes[0].selectionSet);
 
         // Set cache-control hints
         // setGQLCacheHints(info, block, gqlCacheConfig);
@@ -133,7 +131,7 @@ export const createResolvers = async (indexerArg: IndexerInterface, eventWatcher
           block,
           where,
           { limit: first, skip, orderBy, orderDirection },
-          info.fieldNodes[0].selectionSet.selections
+          info
         );
       },
 

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.88",
+    "@cerc-io/solidity-mapper": "^0.2.89",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.88",
-    "@cerc-io/ipld-eth-client": "^0.2.88",
-    "@cerc-io/util": "^0.2.88",
+    "@cerc-io/cache": "^0.2.89",
+    "@cerc-io/ipld-eth-client": "^0.2.89",
+    "@cerc-io/util": "^0.2.89",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.88",
-    "@cerc-io/util": "^0.2.88",
+    "@cerc-io/cache": "^0.2.89",
+    "@cerc-io/util": "^0.2.89",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.88",
-    "@cerc-io/ipld-eth-client": "^0.2.88",
-    "@cerc-io/util": "^0.2.88",
+    "@cerc-io/cache": "^0.2.89",
+    "@cerc-io/ipld-eth-client": "^0.2.89",
+    "@cerc-io/util": "^0.2.89",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.88",
-    "@cerc-io/solidity-mapper": "^0.2.88",
+    "@cerc-io/peer": "^0.2.89",
+    "@cerc-io/solidity-mapper": "^0.2.89",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -52,7 +52,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.88",
+    "@cerc-io/cache": "^0.2.89",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/graph/database.ts
+++ b/packages/util/src/graph/database.ts
@@ -347,18 +347,6 @@ export class GraphDatabase {
     return entityData;
   }
 
-  _defragmentGQLQuerySelections (selections: ReadonlyArray<SelectionNode>, queryInfo: GraphQLResolveInfo): SelectionNode[] {
-    return selections.reduce((acc: SelectionNode[], selection) => {
-      if (selection.kind === 'FragmentSpread') {
-        const fragmentSelections = queryInfo.fragments[selection.name.value].selectionSet.selections;
-
-        return [...acc, ...fragmentSelections];
-      }
-
-      return [...acc, selection];
-    }, []);
-  }
-
   async getEntities<Entity extends ObjectLiteral> (
     queryRunner: QueryRunner,
     entityType: new () => Entity,
@@ -1345,5 +1333,17 @@ export class GraphDatabase {
 
     log(`Total entities in cachedEntities.latestPrunedEntities map: ${totalEntities}`);
     cachePrunedEntitiesCount.set(totalEntities);
+  }
+
+  _defragmentGQLQuerySelections (selections: ReadonlyArray<SelectionNode>, queryInfo: GraphQLResolveInfo): SelectionNode[] {
+    return selections.reduce((acc: SelectionNode[], selection) => {
+      if (selection.kind === 'FragmentSpread') {
+        const fragmentSelections = queryInfo.fragments[selection.name.value].selectionSet.selections;
+
+        return [...acc, ...fragmentSelections];
+      }
+
+      return [...acc, selection];
+    }, []);
   }
 }

--- a/packages/util/src/metrics.ts
+++ b/packages/util/src/metrics.ts
@@ -18,15 +18,6 @@ const DB_SIZE_QUERY = 'SELECT pg_database_size(current_database())';
 
 const log = debug('vulcanize:metrics');
 
-export async function fetchLatestBlockNumber (provider: JsonRpcProvider): Promise<number> {
-  try {
-    return await provider.getBlockNumber();
-  } catch (err) {
-    log('Error fetching latest block number', err);
-    return -1;
-  }
-}
-
 // Create custom metrics
 
 export const lastJobCompletedOn = new client.Gauge({
@@ -212,8 +203,12 @@ const registerUpstreamChainHeadMetrics = async ({ upstream }: Config, rpcProvide
     name: 'latest_upstream_block_number',
     help: 'Latest upstream block number',
     async collect () {
-      const latestBlockNumber = await fetchLatestBlockNumber(ethRpcProvider);
-      this.set(latestBlockNumber);
+      try {
+        const blockNumber = await ethRpcProvider.getBlockNumber();
+        this.set(blockNumber);
+      } catch (err) {
+        log('Error fetching latest block number', err);
+      }
     }
   });
 };


### PR DESCRIPTION
Part of [Regenerate ajna watcher with updated subgraph config](https://www.notion.so/Regenerate-ajna-watcher-with-updated-subgraph-config-c9bbecb033024c13a7515c7f1efc3363)

- Use GQL info param to handle fragements in GQL queries
- Avoid updating latest block metrics on RPC errors