### PR TITLE
Update chain head exporter CLI to support running multiple instances

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.90",
+  "version": "0.2.91",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.90",
-    "@cerc-io/ipld-eth-client": "^0.2.90",
+    "@cerc-io/cache": "^0.2.91",
+    "@cerc-io/ipld-eth-client": "^0.2.91",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.90",
-    "@cerc-io/rpc-eth-client": "^0.2.90",
-    "@cerc-io/util": "^0.2.90",
+    "@cerc-io/peer": "^0.2.91",
+    "@cerc-io/rpc-eth-client": "^0.2.91",
+    "@cerc-io/util": "^0.2.91",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.90",
+    "@cerc-io/util": "^0.2.91",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.90",
-    "@cerc-io/ipld-eth-client": "^0.2.90",
-    "@cerc-io/solidity-mapper": "^0.2.90",
-    "@cerc-io/util": "^0.2.90",
+    "@cerc-io/cli": "^0.2.91",
+    "@cerc-io/ipld-eth-client": "^0.2.91",
+    "@cerc-io/solidity-mapper": "^0.2.91",
+    "@cerc-io/util": "^0.2.91",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.90",
+    "@cerc-io/graph-node": "^0.2.91",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.90",
+    "@cerc-io/solidity-mapper": "^0.2.91",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.90",
-    "@cerc-io/ipld-eth-client": "^0.2.90",
-    "@cerc-io/util": "^0.2.90",
+    "@cerc-io/cache": "^0.2.91",
+    "@cerc-io/ipld-eth-client": "^0.2.91",
+    "@cerc-io/util": "^0.2.91",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.90",
-    "@cerc-io/util": "^0.2.90",
+    "@cerc-io/cache": "^0.2.91",
+    "@cerc-io/util": "^0.2.91",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.90",
-    "@cerc-io/ipld-eth-client": "^0.2.90",
-    "@cerc-io/util": "^0.2.90",
+    "@cerc-io/cache": "^0.2.91",
+    "@cerc-io/ipld-eth-client": "^0.2.91",
+    "@cerc-io/util": "^0.2.91",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.90",
-    "@cerc-io/solidity-mapper": "^0.2.90",
+    "@cerc-io/peer": "^0.2.91",
+    "@cerc-io/solidity-mapper": "^0.2.91",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -52,7 +52,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.90",
+    "@cerc-io/cache": "^0.2.91",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/metrics.ts
+++ b/packages/util/src/metrics.ts
@@ -139,6 +139,8 @@ export const startMetricsServer = async (config: Config, jobQueue: JobQueue, ind
 
   await registerUpstreamChainHeadMetrics(config, endpointIndexes.rpcProviderEndpoint);
 
+  await registerWatcherInfoMetrics();
+
   // Collect default metrics
   client.collectDefaultMetrics();
 
@@ -277,4 +279,14 @@ const registerJobQueueMetrics = async (jobQueue: JobQueue): Promise<void> => {
       });
     }
   });
+};
+
+const registerWatcherInfoMetrics = async (): Promise<void> => {
+  const watcherInfoMetric = new client.Gauge({
+    name: 'watcher_info',
+    help: 'Watcher info (static)',
+    labelNames: ['version', 'commitHash']
+  });
+
+  watcherInfoMetric.set({ version: process.env.npm_package_version, commitHash: process.env.npm_package_commitHash }, 1);
 };


### PR DESCRIPTION
Part of https://www.notion.so/Deploy-v2-and-updated-v3-sushiswap-subgraphs-e331945fdeea487c890706fc22c6cc94

- Update upstream RPC for metrics with active endpoint
- Export metrics for watcher package version and commitHash