### PR TITLE
Export codegen config in a generated watcher

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -118,6 +118,8 @@ Steps:
 
 * Update generated watcher's config (`environments/local.toml`) as required
 
+* Update generated codegen config (`codegen-config.yml`) to remove / replace your system's absolute paths
+
 ## Development
 
 * `lint`

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -160,6 +160,12 @@ Steps:
   yarn
   ```
 
+* Run build:
+
+  ```bash
+  yarn build
+  ```
+
 * In the config file (`environments/local.toml`):
 
   * Update the state checkpoint settings.

--- a/packages/codegen/src/generate-code.ts
+++ b/packages/codegen/src/generate-code.ts
@@ -65,7 +65,8 @@ const main = async (): Promise<void> => {
     })
     .argv;
 
-  const config = await getConfig(path.resolve(argv['config-file']));
+  const configFile = path.resolve(argv['config-file']);
+  const config = await getConfig(configFile);
 
   // Create an array of flattened contract strings.
   const contracts: any[] = [];
@@ -120,7 +121,7 @@ const main = async (): Promise<void> => {
 
   parseAndVisit(visitor, contracts, config.mode);
 
-  generateWatcher(visitor, contracts, config, overwriteExisting);
+  generateWatcher(visitor, contracts, configFile, config, overwriteExisting);
 };
 
 function parseAndVisit (visitor: Visitor, contracts: any[], mode: string) {
@@ -162,7 +163,7 @@ function parseAndVisit (visitor: Visitor, contracts: any[], mode: string) {
   }
 }
 
-function generateWatcher (visitor: Visitor, contracts: any[], config: any, overWriteExisting = false) {
+function generateWatcher (visitor: Visitor, contracts: any[], configFile: string, config: any, overWriteExisting = false) {
   // Prepare directory structure for the watcher.
   let outputDir = '';
 
@@ -197,6 +198,13 @@ function generateWatcher (visitor: Visitor, contracts: any[], config: any, overW
   }
 
   let outStream: Writable;
+
+  // Export the codegen config file
+  const configFileContent = fs.readFileSync(configFile, 'utf8');
+  outStream = outputDir
+    ? fs.createWriteStream(path.join(outputDir, 'codegen-config.yml'))
+    : process.stdout;
+  outStream.write(configFileContent);
 
   // Export artifacts for the contracts.
   contracts.forEach((contract: any) => {

--- a/packages/codegen/src/templates/readme-template.handlebars
+++ b/packages/codegen/src/templates/readme-template.handlebars
@@ -15,6 +15,12 @@
   yarn
   ```
 
+* Run build:
+
+  ```bash
+  yarn build
+  ```
+
 * Create a postgres12 database for the watcher:
 
   ```bash


### PR DESCRIPTION
Part of [Generate secured-finance subgraph watcher with codegen](https://www.notion.so/Generate-secured-finance-subgraph-watcher-with-codegen-2923413e0af54ea787c5435d6966f3bb)