### PR TITLE
Support events handlers in multiple data sources for a contract address

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.101",
+  "version": "0.2.102",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.101",
-    "@cerc-io/ipld-eth-client": "^0.2.101",
+    "@cerc-io/cache": "^0.2.102",
+    "@cerc-io/ipld-eth-client": "^0.2.102",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.101",
-    "@cerc-io/rpc-eth-client": "^0.2.101",
-    "@cerc-io/util": "^0.2.101",
+    "@cerc-io/peer": "^0.2.102",
+    "@cerc-io/rpc-eth-client": "^0.2.102",
+    "@cerc-io/util": "^0.2.102",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.101",
+    "@cerc-io/util": "^0.2.102",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/data/entities/Contract.yaml
+++ b/packages/codegen/src/data/entities/Contract.yaml
@@ -2,6 +2,7 @@ className: Contract
 indexOn:
   - columns:
       - address
+      - kind
     unique: true
 columns:
   - name: id

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -525,23 +525,27 @@ export class Indexer implements IndexerInterface {
   }
 
   {{/if}}
-  parseEventNameAndArgs (kind: string, logObj: any): { eventParsed: boolean, eventDetails: any } {
+  parseEventNameAndArgs (watchedContracts: Contract[], logObj: any): { eventParsed: boolean, eventDetails: any } {
     const { topics, data } = logObj;
+    let logDescription: ethers.utils.LogDescription | undefined;
 
-    const contract = this._contractMap.get(kind);
-    assert(contract);
+    for (const watchedContract of watchedContracts) {
+      const contract = this._contractMap.get(watchedContract.kind);
+      assert(contract);
 
-    let logDescription: ethers.utils.LogDescription;
-    try {
-      logDescription = contract.parseLog({ data, topics });
-    } catch (err) {
-      // Return if no matching event found
-      if ((err as Error).message.includes('no matching event')) {
-        log(`WARNING: Skipping event for contract ${kind} as no matching event found in the ABI`);
-        return { eventParsed: false, eventDetails: {} };
+      try {
+        logDescription = contract.parseLog({ data, topics });
+        break;
+      } catch (err) {
+        // Continue loop only if no matching event found
+        if (!((err as Error).message.includes('no matching event'))) {
+          throw err;
+        }
       }
+    }
 
-      throw err;
+    if (!logDescription) {
+      return { eventParsed: false, eventDetails: {} };
     }
 
     const { eventName, eventInfo, eventSignature } = this._baseIndexer.parseEvent(logDescription);
@@ -647,8 +651,8 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getEventsByFilter(blockHash, contract, name);
   }
 
-  isWatchedContract (address : string): Contract | undefined {
-    return this._baseIndexer.isWatchedContract(address);
+  isContractAddressWatched (address : string): Contract[] | undefined {
+    return this._baseIndexer.isContractAddressWatched(address);
   }
 
   getWatchedContracts (): Contract[] {

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.101",
-    "@cerc-io/ipld-eth-client": "^0.2.101",
-    "@cerc-io/solidity-mapper": "^0.2.101",
-    "@cerc-io/util": "^0.2.101",
+    "@cerc-io/cli": "^0.2.102",
+    "@cerc-io/ipld-eth-client": "^0.2.102",
+    "@cerc-io/solidity-mapper": "^0.2.102",
+    "@cerc-io/util": "^0.2.102",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.101",
+    "@cerc-io/graph-node": "^0.2.102",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.101",
+    "@cerc-io/solidity-mapper": "^0.2.102",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.101",
-    "@cerc-io/ipld-eth-client": "^0.2.101",
-    "@cerc-io/util": "^0.2.101",
+    "@cerc-io/cache": "^0.2.102",
+    "@cerc-io/ipld-eth-client": "^0.2.102",
+    "@cerc-io/util": "^0.2.102",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/graph-node/src/loader.ts
+++ b/packages/graph-node/src/loader.ts
@@ -50,6 +50,7 @@ export interface Context {
   rpcSupportsBlockHashParam: boolean;
   block?: Block;
   contractAddress?: string;
+  dataSourceName?: string;
 }
 
 const log = debug('vulcanize:graph-node');
@@ -719,13 +720,14 @@ export const instantiate = async (
       },
       'dataSource.context': async () => {
         assert(context.contractAddress);
-        const contract = indexer.isWatchedContract(context.contractAddress);
+        const watchedContracts = indexer.isContractAddressWatched(context.contractAddress);
+        const dataSourceContract = watchedContracts?.find(contract => contract.kind === context.dataSourceName);
 
-        if (!contract) {
+        if (!dataSourceContract) {
           return null;
         }
 
-        return database.toGraphContext(instanceExports, contract.context);
+        return database.toGraphContext(instanceExports, dataSourceContract.context);
       },
       'dataSource.network': async () => {
         assert(dataSource);

--- a/packages/graph-node/src/watcher.ts
+++ b/packages/graph-node/src/watcher.ts
@@ -216,9 +216,20 @@ export class GraphWatcher {
       const { instance, contractInterface } = this._dataSourceMap[dataSource.name];
       assert(instance);
       const { exports: instanceExports } = instance;
+      let eventTopic: string;
+
+      try {
+        eventTopic = contractInterface.getEventTopic(eventSignature);
+      } catch (err) {
+        // Continue loop only if no matching event found
+        if (!((err as Error).message.includes('no matching event'))) {
+          throw err;
+        }
+
+        continue;
+      }
 
       // Get event handler based on event topic (from event signature).
-      const eventTopic = contractInterface.getEventTopic(eventSignature);
       const eventHandler = dataSource.mapping.eventHandlers.find((eventHandler: any) => {
         // The event signature we get from logDescription is different than that given in the subgraph yaml file.
         // For eg. event in subgraph.yaml: Stake(indexed address,uint256); from logDescription: Stake(address,uint256)

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -248,7 +248,7 @@ export class Indexer implements IndexerInterface {
     return undefined;
   }
 
-  isWatchedContract (address : string): ContractInterface | undefined {
+  isContractAddressWatched (address : string): ContractInterface[] | undefined {
     return undefined;
   }
 

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.101",
-    "@cerc-io/util": "^0.2.101",
+    "@cerc-io/cache": "^0.2.102",
+    "@cerc-io/util": "^0.2.102",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.101",
-    "@cerc-io/ipld-eth-client": "^0.2.101",
-    "@cerc-io/util": "^0.2.101",
+    "@cerc-io/cache": "^0.2.102",
+    "@cerc-io/ipld-eth-client": "^0.2.102",
+    "@cerc-io/util": "^0.2.102",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.101",
-    "@cerc-io/solidity-mapper": "^0.2.101",
+    "@cerc-io/peer": "^0.2.102",
+    "@cerc-io/solidity-mapper": "^0.2.102",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -54,7 +54,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.101",
+    "@cerc-io/cache": "^0.2.102",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -665,7 +665,7 @@ export class Database {
   async saveContract (repo: Repository<ContractInterface>, address: string, kind: string, checkpoint: boolean, startingBlock: number, context?: any): Promise<ContractInterface> {
     const contract = await repo
       .createQueryBuilder()
-      .where('address = :address', { address })
+      .where('address = :address AND kind = :kind', { address, kind })
       .getOne();
 
     const entity = repo.create({ address, kind, checkpoint, startingBlock, context });

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -202,8 +202,8 @@ export interface IndexerInterface {
   saveEventEntity (dbEvent: EventInterface): Promise<EventInterface>
   saveEvents (dbEvents: DeepPartial<EventInterface>[]): Promise<void>
   processEvent (event: EventInterface, extraData: ExtraEventData): Promise<void>
-  parseEventNameAndArgs?: (kind: string, logObj: any) => { eventParsed: boolean, eventDetails: any }
-  isWatchedContract: (address: string) => ContractInterface | undefined;
+  parseEventNameAndArgs?: (watchedContracts: ContractInterface[], logObj: any) => { eventParsed: boolean, eventDetails: any }
+  isContractAddressWatched: (address: string) => ContractInterface[] | undefined;
   getWatchedContracts: () => ContractInterface[]
   getContractsByKind?: (kind: string) => ContractInterface[]
   addContracts?: () => Promise<void>


### PR DESCRIPTION
Part of [Generate secured-finance subgraph watcher with codegen](https://www.notion.so/Generate-secured-finance-subgraph-watcher-with-codegen-2923413e0af54ea787c5435d6966f3bb)

- Update unique key for `address` and `kind` in watcher contracts table
- Update graph-node package event handling to process events for multiple data sources (from subgraph config)