### PR TITLE
Handle template create in subgraph watcher during reorgs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.107",
+  "version": "0.2.108",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.107",
-    "@cerc-io/ipld-eth-client": "^0.2.107",
+    "@cerc-io/cache": "^0.2.108",
+    "@cerc-io/ipld-eth-client": "^0.2.108",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.107",
-    "@cerc-io/rpc-eth-client": "^0.2.107",
-    "@cerc-io/util": "^0.2.107",
+    "@cerc-io/peer": "^0.2.108",
+    "@cerc-io/rpc-eth-client": "^0.2.108",
+    "@cerc-io/util": "^0.2.108",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.107",
+    "@cerc-io/util": "^0.2.108",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -635,6 +635,10 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.watchContract(address, kind, checkpoint, startingBlock, context);
   }
 
+  async removeContract (address: string, kind: string): Promise<void> {
+    return this._baseIndexer.removeContract(address, kind);
+  }
+
   updateStateStatusMap (address: string, stateStatus: StateStatus): void {
     this._baseIndexer.updateStateStatusMap(address, stateStatus);
   }

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.107",
-    "@cerc-io/ipld-eth-client": "^0.2.107",
-    "@cerc-io/solidity-mapper": "^0.2.107",
-    "@cerc-io/util": "^0.2.107",
+    "@cerc-io/cli": "^0.2.108",
+    "@cerc-io/ipld-eth-client": "^0.2.108",
+    "@cerc-io/solidity-mapper": "^0.2.108",
+    "@cerc-io/util": "^0.2.108",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.107",
+    "@cerc-io/graph-node": "^0.2.108",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.107",
+    "@cerc-io/solidity-mapper": "^0.2.108",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.107",
-    "@cerc-io/ipld-eth-client": "^0.2.107",
-    "@cerc-io/util": "^0.2.107",
+    "@cerc-io/cache": "^0.2.108",
+    "@cerc-io/ipld-eth-client": "^0.2.108",
+    "@cerc-io/util": "^0.2.108",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -276,6 +276,10 @@ export class Indexer implements IndexerInterface {
     return undefined;
   }
 
+  async removeContract (address: string, kind: string): Promise<void> {
+    return undefined;
+  }
+
   async processBlock (blockProgress: BlockProgressInterface): Promise<void> {
     return undefined;
   }

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.107",
-    "@cerc-io/util": "^0.2.107",
+    "@cerc-io/cache": "^0.2.108",
+    "@cerc-io/util": "^0.2.108",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.107",
-    "@cerc-io/ipld-eth-client": "^0.2.107",
-    "@cerc-io/util": "^0.2.107",
+    "@cerc-io/cache": "^0.2.108",
+    "@cerc-io/ipld-eth-client": "^0.2.108",
+    "@cerc-io/util": "^0.2.108",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.107",
-    "@cerc-io/solidity-mapper": "^0.2.107",
+    "@cerc-io/peer": "^0.2.108",
+    "@cerc-io/solidity-mapper": "^0.2.108",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -55,7 +55,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.107",
+    "@cerc-io/cache": "^0.2.108",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -920,6 +920,22 @@ export class Indexer {
     }
   }
 
+  async removeContract (address: string, kind: string): Promise<void> {
+    const dbTx = await this._db.createTransactionRunner();
+
+    try {
+      await this._db.deleteEntitiesByConditions(dbTx, 'contract', { kind, address });
+      this._clearWatchedContracts(
+        watchedContract => watchedContract.kind === kind && watchedContract.address === address
+      );
+    } catch (error) {
+      await dbTx.rollbackTransaction();
+      throw error;
+    } finally {
+      await dbTx.release();
+    }
+  }
+
   cacheContract (contract: ContractInterface): void {
     if (!this._watchedContractsByAddressMap[contract.address]) {
       this._watchedContractsByAddressMap[contract.address] = [];

--- a/packages/util/src/server.ts
+++ b/packages/util/src/server.ts
@@ -97,23 +97,34 @@ export const createAndStartServer = async (
 
   await server.start();
 
-  server.applyMiddleware({
-    app,
-    path: gqlPath
-  });
-
   const rpcPath = serverConfig.ethRPC?.path ?? DEFAULT_ETH_RPC_PATH;
+  const rpcEnabled = serverConfig.ethRPC?.enabled;
 
-  if (serverConfig.ethRPC?.enabled) {
+  // Apply GraphQL middleware
+  const applyGraphQLMiddleware = () => {
+    console.log('applyGraphQLMiddleware');
+    server.applyMiddleware({
+      app,
+      path: gqlPath
+    });
+  };
+
+  // Apply RPC middleware
+  const applyRPCMiddleware = () => {
+    console.log('applyRPCMiddleware');
+    if (!rpcEnabled) {
+      return;
+    }
+
     // Create a JSON-RPC server to handle ETH RPC calls
     const rpcServer = jayson.Server(ethRPCHandlers);
 
-    // Mount the JSON-RPC server to ETH_RPC_PATH
+    // Mount the JSON-RPC server to rpcPath
     app.use(
       rpcPath,
       jsonParser(),
       (req: any, res: any, next: () => void) => {
-        // Convert all GET requests to POST to avoid getting rejected from jayson server middleware
+        // Convert all GET requests to POST to avoid getting rejected by jayson server middleware
         if (jayson.Utils.isMethod(req, 'GET')) {
           req.method = 'POST';
         }
@@ -121,15 +132,32 @@ export const createAndStartServer = async (
       },
       rpcServer.middleware()
     );
+  };
+
+  // Apply middlewares based on path specificity
+  if (isPathMoreSpecific(rpcPath, gqlPath)) {
+    applyRPCMiddleware();
+    applyGraphQLMiddleware();
+  } else {
+    applyGraphQLMiddleware();
+    applyRPCMiddleware();
   }
 
   httpServer.listen(port, host, () => {
-    log(`GQL server is listening on http://${host}:${port}${server.graphqlPath}`);
+    log(`GQL server is listening on http://${host}:${port}${gqlPath}`);
 
-    if (serverConfig.ethRPC?.enabled) {
+    if (rpcEnabled) {
       log(`ETH JSON RPC server is listening on http://${host}:${port}${rpcPath}`);
     }
   });
 
   return server;
 };
+
+// Determine which path is more specific (more segments)
+function isPathMoreSpecific (path1: string, path2: string) {
+  const path1Segments = path1.split('/').filter(segment => segment !== '');
+  const path2Segments = path2.split('/').filter(segment => segment !== '');
+
+  return path1Segments.length > path2Segments.length;
+}

--- a/packages/util/src/server.ts
+++ b/packages/util/src/server.ts
@@ -102,7 +102,6 @@ export const createAndStartServer = async (
 
   // Apply GraphQL middleware
   const applyGraphQLMiddleware = () => {
-    console.log('applyGraphQLMiddleware');
     server.applyMiddleware({
       app,
       path: gqlPath
@@ -111,7 +110,6 @@ export const createAndStartServer = async (
 
   // Apply RPC middleware
   const applyRPCMiddleware = () => {
-    console.log('applyRPCMiddleware');
     if (!rpcEnabled) {
       return;
     }

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -217,6 +217,7 @@ export interface IndexerInterface {
   addContracts?: () => Promise<void>
   cacheContract: (contract: ContractInterface) => void;
   watchContract: (address: string, kind: string, checkpoint: boolean, startingBlock: number, context?: any) => Promise<void>
+  removeContract: (address: string, kind: string) => Promise<void>;
   getEntityTypesMap?: () => Map<string, { [key: string]: string }>
   getRelationsMap?: () => Map<any, { [key: string]: any }>
   processInitialState: (contractAddress: string, blockHash: string) => Promise<any>


### PR DESCRIPTION
Part of [Handle template create events processing during reorgs](https://www.notion.so/Handle-template-create-events-processing-during-reorgs-87b3c097d0ef4e29a4a14f6f879799fd) and [Watcher ETH JSON-RPC wrapper](https://www.notion.so/Watcher-ETH-JSON-RPC-wrapper-ba817da117c643779538aee6e2ebae0f)

- Remove existing watched contract when encountered during template create in subgraph watcher
  - Reprocess block without existing watched contract
  - Scenario arises during reorgs with block events resulting to subgraph template create
- Apply GQL and RPC server middlewares ordered on requested paths
  - Apply the one with more path segments first to avoid it's requests getting directed to the other