### PR TITLE
Add ETH RPC API to watcher server

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -32,7 +32,8 @@ import {
   readParty,
   UpstreamConfig,
   fillBlocks,
-  createGQLLogger
+  createGQLLogger,
+  createEthRPCHandlers
 } from '@cerc-io/util';
 import { TypeSource } from '@graphql-tools/utils';
 import type {
@@ -276,8 +277,7 @@ export class ServerCmd {
       gqlLogger: winston.Logger
     ) => Promise<any>,
     typeDefs: TypeSource,
-    paymentsManager?: PaymentsManager,
-    createEthRPCHandlers?: (indexer: IndexerInterface, ethProvider: JsonRpcProvider) => Promise<any>
+    paymentsManager?: PaymentsManager
   ): Promise<{
     app: Application,
     server: ApolloServer
@@ -319,7 +319,7 @@ export class ServerCmd {
     const gqlLogger = createGQLLogger(config.server.gql.logDir);
     const resolvers = await createResolvers(indexer, eventWatcher, gqlLogger);
 
-    const ethRPCHandlers = createEthRPCHandlers ? await createEthRPCHandlers(indexer, ethProvider) : {};
+    const ethRPCHandlers = await createEthRPCHandlers(indexer, ethProvider);
 
     // Create an Express app
     const app: Application = express();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -277,7 +277,7 @@ export class ServerCmd {
     ) => Promise<any>,
     typeDefs: TypeSource,
     paymentsManager?: PaymentsManager,
-    createEthRPCHandlers?: (indexer: IndexerInterface) => Promise<any>
+    createEthRPCHandlers?: (indexer: IndexerInterface, ethProvider: JsonRpcProvider) => Promise<any>
   ): Promise<{
     app: Application,
     server: ApolloServer
@@ -286,6 +286,7 @@ export class ServerCmd {
     const jobQueue = this._baseCmd.jobQueue;
     const indexer = this._baseCmd.indexer;
     const eventWatcher = this._baseCmd.eventWatcher;
+    const ethProvider = this._baseCmd.ethProvider;
 
     assert(config);
     assert(jobQueue);
@@ -318,7 +319,7 @@ export class ServerCmd {
     const gqlLogger = createGQLLogger(config.server.gql.logDir);
     const resolvers = await createResolvers(indexer, eventWatcher, gqlLogger);
 
-    const ethRPCHandlers = createEthRPCHandlers ? await createEthRPCHandlers(indexer) : {};
+    const ethRPCHandlers = createEthRPCHandlers ? await createEthRPCHandlers(indexer, ethProvider) : {};
 
     // Create an Express app
     const app: Application = express();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -276,7 +276,8 @@ export class ServerCmd {
       gqlLogger: winston.Logger
     ) => Promise<any>,
     typeDefs: TypeSource,
-    paymentsManager?: PaymentsManager
+    paymentsManager?: PaymentsManager,
+    createEthRPCHandlers?: (indexer: IndexerInterface) => Promise<any>
   ): Promise<{
     app: Application,
     server: ApolloServer
@@ -317,9 +318,11 @@ export class ServerCmd {
     const gqlLogger = createGQLLogger(config.server.gql.logDir);
     const resolvers = await createResolvers(indexer, eventWatcher, gqlLogger);
 
+    const ethRPCHandlers = createEthRPCHandlers ? await createEthRPCHandlers(indexer) : {};
+
     // Create an Express app
     const app: Application = express();
-    const server = await createAndStartServer(app, typeDefs, resolvers, config.server, paymentsManager);
+    const server = await createAndStartServer(app, typeDefs, resolvers, ethRPCHandlers, config.server, paymentsManager);
 
     await startGQLMetricsServer(config);
 

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 import { DeepPartial, FindConditions, FindManyOptions } from 'typeorm';
-import { providers } from 'ethers';
+import { ethers } from 'ethers';
 
 import {
   IndexerInterface,
@@ -28,6 +28,8 @@ import { GetStorageAt, getStorageValue, MappingKey, StorageLayout } from '@cerc-
 export class Indexer implements IndexerInterface {
   _getStorageAt: GetStorageAt;
   _storageLayoutMap: Map<string, StorageLayout> = new Map();
+  _contractMap: Map<string, ethers.utils.Interface> = new Map();
+
   eventSignaturesMap: Map<string, string[]> = new Map();
 
   constructor (ethClient: EthClient, storageLayoutMap?: Map<string, StorageLayout>) {
@@ -48,6 +50,10 @@ export class Indexer implements IndexerInterface {
 
   get storageLayoutMap (): Map<string, StorageLayout> {
     return this._storageLayoutMap;
+  }
+
+  get contractMap (): Map<string, ethers.utils.Interface> {
+    return this._contractMap;
   }
 
   async init (): Promise<void> {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -36,6 +36,7 @@
     "it-length-prefixed": "^8.0.4",
     "it-pipe": "^2.0.5",
     "it-pushable": "^3.1.2",
+    "jayson": "^4.1.2",
     "js-yaml": "^4.1.0",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -252,6 +252,9 @@ export interface ServerConfig {
   // Flag to specify whether RPC endpoint supports block hash as block tag parameter
   // https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block
   rpcSupportsBlockHashParam: boolean;
+
+  // Enable ETH JSON RPC server at /rpc
+  enableEthRPCServer: boolean;
 }
 
 export interface FundingAmountsConfig {

--- a/packages/util/src/eth-rpc-handlers.ts
+++ b/packages/util/src/eth-rpc-handlers.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { IndexerInterface } from './types';
+
+export const createEthRPCHandlers = async (
+  indexer: IndexerInterface
+): Promise<any> => {
+  return {
+    eth_blockNumber: async (args: any, callback: any) => {
+      const syncStatus = await indexer.getSyncStatus();
+      const result = syncStatus ? `0x${syncStatus.latestProcessedBlockNumber.toString(16)}` : '0x';
+
+      callback(null, result);
+    },
+
+    eth_call: async (args: any, callback: any) => {
+      // TODO: Implement
+    },
+
+    eth_getLogs: async (args: any, callback: any) => {
+      // TODO: Implement
+    }
+  };
+};

--- a/packages/util/src/eth-rpc-handlers.ts
+++ b/packages/util/src/eth-rpc-handlers.ts
@@ -1,6 +1,25 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { IndexerInterface } from './types';
 
+const CODE_INVALID_PARAMS = -32602;
+const CODE_INTERNAL_ERROR = -32603;
+const CODE_SERVER_ERROR = -32000;
+
+const ERROR_CONTRACT_MAP_NOT_SET = 'Contract map not set';
+const ERROR_CONTRACT_ABI_NOT_FOUND = 'Contract ABI not found';
+const ERROR_CONTRACT_INSUFFICIENT_PARAMS = 'Insufficient params';
+const ERROR_CONTRACT_NOT_RECOGNIZED = 'Contract not recognized';
+const ERROR_CONTRACT_METHOD_NOT_FOUND = 'Contract method not found';
+const ERROR_METHOD_NOT_IMPLEMENTED = 'Method not implemented';
+
+class ErrorWithCode extends Error {
+  code: number;
+  constructor (code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
 export const createEthRPCHandlers = async (
   indexer: IndexerInterface
 ): Promise<any> => {
@@ -13,48 +32,64 @@ export const createEthRPCHandlers = async (
     },
 
     eth_call: async (args: any, callback: any) => {
-      // TODO: Handle empty args
-      // TODO: Set errors in response
       // TODO: Parse blockTag
 
-      const { to, data, blockTag } = args[0];
+      try {
+        if (args.length === 0) {
+          throw new ErrorWithCode(CODE_INVALID_PARAMS, ERROR_CONTRACT_INSUFFICIENT_PARAMS);
+        }
 
-      // For values other than blockHash, resolve value from block_progress table
-      const latestBlock = await indexer.getLatestCanonicalBlock();
-      const blockHash = latestBlock?.blockHash;
+        const { to, data, blockTag } = args[0];
 
-      const watchedContract = indexer.getWatchedContracts().find(contract => contract.address === to);
-      if (!watchedContract) {
-        throw new Error('Contract not recognized');
-      }
+        if (!indexer.contractMap) {
+          throw new ErrorWithCode(CODE_INTERNAL_ERROR, ERROR_CONTRACT_MAP_NOT_SET);
+        }
 
-      if (!indexer.contractMap) {
-        throw new Error('Contract map not found');
-      }
+        // For values other than blockHash, resolve value from block_progress table
+        const latestBlock = await indexer.getLatestCanonicalBlock();
+        const blockHash = latestBlock?.blockHash;
 
-      const contractInterface = indexer.contractMap.get(watchedContract.kind);
-      if (!contractInterface) {
-        throw new Error('Contract ABI not found');
-      }
+        const watchedContract = indexer.getWatchedContracts().find(contract => contract.address === to);
+        if (!watchedContract) {
+          throw new ErrorWithCode(CODE_INVALID_PARAMS, ERROR_CONTRACT_NOT_RECOGNIZED);
+        }
 
-      // Slice out method signature
-      const functionSelector = data.slice(0, 10);
+        const contractInterface = indexer.contractMap.get(watchedContract.kind);
+        if (!contractInterface) {
+          throw new ErrorWithCode(CODE_INTERNAL_ERROR, ERROR_CONTRACT_ABI_NOT_FOUND);
+        }
 
-      // Find the matching function from the ABI
-      const functionFragment = contractInterface.getFunction(functionSelector);
-      if (!functionFragment) {
-        throw new Error('Method not found');
-      }
+        // Slice out method signature from data
+        const functionSelector = data.slice(0, 10);
 
-      // Decode the data based on the matched function
-      const decodedData = contractInterface.decodeFunctionData(functionFragment, data);
+        // Find the matching function from the ABI
+        const functionFragment = contractInterface.getFunction(functionSelector);
+        if (!functionFragment) {
+          throw new ErrorWithCode(CODE_INVALID_PARAMS, ERROR_CONTRACT_METHOD_NOT_FOUND);
+        }
 
-      const functionName = functionFragment.name;
-      const indexerMethod = (indexer as any)[functionName].bind(indexer);
-      if (indexerMethod && typeof indexerMethod === 'function') {
+        // Decode the data based on the matched function
+        const decodedData = contractInterface.decodeFunctionData(functionFragment, data);
+
+        const functionName = functionFragment.name;
+        const indexerMethod = (indexer as any)[functionName].bind(indexer);
+        if (!indexerMethod) {
+          throw new ErrorWithCode(CODE_SERVER_ERROR, ERROR_METHOD_NOT_IMPLEMENTED);
+        }
+
         const result = await indexerMethod(blockHash, to, ...decodedData);
         const encodedResult = contractInterface.encodeFunctionResult(functionFragment, [result.value]);
+
         callback(null, encodedResult);
+      } catch (error: any) {
+        let callBackError;
+        if (error instanceof ErrorWithCode) {
+          callBackError = { code: error.code, message: error.message };
+        } else {
+          callBackError = { code: CODE_SERVER_ERROR, message: error.message };
+        }
+
+        callback(callBackError);
       }
     },
 

--- a/packages/util/src/eth-rpc-handlers.ts
+++ b/packages/util/src/eth-rpc-handlers.ts
@@ -13,7 +13,49 @@ export const createEthRPCHandlers = async (
     },
 
     eth_call: async (args: any, callback: any) => {
-      // TODO: Implement
+      // TODO: Handle empty args
+      // TODO: Set errors in response
+      // TODO: Parse blockTag
+
+      const { to, data, blockTag } = args[0];
+
+      // For values other than blockHash, resolve value from block_progress table
+      const latestBlock = await indexer.getLatestCanonicalBlock();
+      const blockHash = latestBlock?.blockHash;
+
+      const watchedContract = indexer.getWatchedContracts().find(contract => contract.address === to);
+      if (!watchedContract) {
+        throw new Error('Contract not recognized');
+      }
+
+      if (!indexer.contractMap) {
+        throw new Error('Contract map not found');
+      }
+
+      const contractInterface = indexer.contractMap.get(watchedContract.kind);
+      if (!contractInterface) {
+        throw new Error('Contract ABI not found');
+      }
+
+      // Slice out method signature
+      const functionSelector = data.slice(0, 10);
+
+      // Find the matching function from the ABI
+      const functionFragment = contractInterface.getFunction(functionSelector);
+      if (!functionFragment) {
+        throw new Error('Method not found');
+      }
+
+      // Decode the data based on the matched function
+      const decodedData = contractInterface.decodeFunctionData(functionFragment, data);
+
+      const functionName = functionFragment.name;
+      const indexerMethod = (indexer as any)[functionName].bind(indexer);
+      if (indexerMethod && typeof indexerMethod === 'function') {
+        const result = await indexerMethod(blockHash, to, ...decodedData);
+        const encodedResult = contractInterface.encodeFunctionResult(functionFragment, [result.value]);
+        callback(null, encodedResult);
+      }
     },
 
     eth_getLogs: async (args: any, callback: any) => {

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -28,3 +28,4 @@ export * from './eth';
 export * from './consensus';
 export * from './validate-config';
 export * from './logger';
+export * from './eth-rpc-handlers';

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -3,7 +3,7 @@
 //
 
 import { Connection, DeepPartial, EntityTarget, FindConditions, FindManyOptions, ObjectLiteral, QueryRunner } from 'typeorm';
-import { Transaction } from 'ethers';
+import { ethers, Transaction } from 'ethers';
 
 import { MappingKey, StorageLayout } from '@cerc-io/solidity-mapper';
 
@@ -161,6 +161,7 @@ export interface IndexerInterface {
   readonly serverConfig: ServerConfig
   readonly upstreamConfig: UpstreamConfig
   readonly storageLayoutMap: Map<string, StorageLayout>
+  readonly contractMap: Map<string, ethers.utils.Interface>
   // eslint-disable-next-line no-use-before-define
   readonly graphWatcher?: GraphWatcherInterface
   init (): Promise<void>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,6 +3635,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/connect@^3.4.33":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cors@2.8.12":
   version "2.8.12"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
@@ -3848,6 +3855,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
+"@types/node@^12.12.54":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
 "@types/node@^12.12.6":
   version "12.20.13"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz"
@@ -3953,6 +3965,13 @@
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
+"@types/ws@^7.4.4":
+  version "7.4.7"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ws@^8.5.3":
   version "8.5.4"
@@ -4151,7 +4170,7 @@
   resolved "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-JSONStream@^1.0.4:
+JSONStream@^1.0.4, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
   integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
@@ -7398,6 +7417,18 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==
+  dependencies:
+    es6-promise "^4.0.3"
+
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz"
@@ -8292,6 +8323,11 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+eyes@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
 fake-merkle-patricia-tree@^1.0.1:
   version "1.0.1"
@@ -10422,6 +10458,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
@@ -10650,6 +10691,24 @@ jackspeak@^2.3.5:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
+
+jayson@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-4.1.2.tgz#443c26a8658703e0b2e881117b09395d88b6982e"
+  integrity sha512-5nzMWDHy6f+koZOuYsArh2AXs73NfWYVlFyJJuCedr93GpY+Ku8qq10ropSXVfHK+H0T6paA88ww+/dV+1fBNA==
+  dependencies:
+    "@types/connect" "^3.4.33"
+    "@types/node" "^12.12.54"
+    "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
+    commander "^2.20.3"
+    delay "^5.0.0"
+    es6-promisify "^5.0.0"
+    eyes "^0.1.8"
+    isomorphic-ws "^4.0.1"
+    json-stringify-safe "^5.0.1"
+    uuid "^8.3.2"
+    ws "^7.5.10"
 
 js-sdsl@^4.1.4:
   version "4.4.0"
@@ -17028,6 +17087,11 @@ ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^7.5.10:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.11.0, ws@^8.12.1, ws@^8.4.0:
   version "8.13.0"


### PR DESCRIPTION
Part of [Watcher ETH JSON-RPC wrapper](https://www.notion.so/Watcher-ETH-JSON-RPC-wrapper-ba817da117c643779538aee6e2ebae0f)

- Added a JSON RPC server at `/rpc` path to the watcher server behind a flag `enableEthRPCServer`
- Added support for `eth_blockNumber` and `eth_call` methods
  - Currently supported block tags: block hash, block number, `latest`
- To be handled in a follow on PR:
  - Add support for `eth_getLogs` method
  - Handle `GET` requests to match Geth's behaviour
  - Required codegen changes