### PR TITLE
Add ETH RPC API to get logs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.106",
+  "version": "0.2.107",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.106",
-    "@cerc-io/ipld-eth-client": "^0.2.106",
+    "@cerc-io/cache": "^0.2.107",
+    "@cerc-io/ipld-eth-client": "^0.2.107",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.106",
-    "@cerc-io/rpc-eth-client": "^0.2.106",
-    "@cerc-io/util": "^0.2.106",
+    "@cerc-io/peer": "^0.2.107",
+    "@cerc-io/rpc-eth-client": "^0.2.107",
+    "@cerc-io/util": "^0.2.107",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -323,7 +323,14 @@ export class ServerCmd {
 
     // Create an Express app
     const app: Application = express();
-    const server = await createAndStartServer(app, typeDefs, resolvers, ethRPCHandlers, config.server, paymentsManager);
+    const server = await createAndStartServer(
+      app,
+      typeDefs,
+      resolvers,
+      ethRPCHandlers,
+      config.server,
+      paymentsManager
+    );
 
     await startGQLMetricsServer(config);
 

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.106",
+    "@cerc-io/util": "^0.2.107",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -25,6 +25,9 @@
   # Flag to specify whether RPC endpoint supports block hash as block tag parameter
   rpcSupportsBlockHashParam = true
 
+  # Enable ETH JSON RPC server at /rpc
+  enableEthRPCServer = true
+
   # Server GQL config
   [server.gql]
     path = "/graphql"

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -28,7 +28,7 @@
   # Enable ETH JSON RPC server at /rpc
   enableEthRPCServer = true
 
-  // Max number of logs that can be returned in a single getLogs request (default: 10000)
+  # Max number of logs that can be returned in a single getLogs request (default: 10000)
   ethGetLogsResultLimit = 10000
 
   # Server GQL config

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -28,6 +28,9 @@
   # Enable ETH JSON RPC server at /rpc
   enableEthRPCServer = true
 
+  // Max number of logs that can be returned in a single getLogs request (default: 10000)
+  ethGetLogsResultLimit = 10000
+
   # Server GQL config
   [server.gql]
     path = "/graphql"

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -199,6 +199,12 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getEventsInRange(repo, fromBlockNumber, toBlockNumber);
   }
 
+  async getEvents (options: FindManyOptions<Event>): Promise<Array<Event>> {
+    const repo = this._conn.getRepository(Event);
+
+    return this._baseDatabase.getEvents(repo, options);
+  }
+
   async saveEventEntity (queryRunner: QueryRunner, entity: Event): Promise<Event> {
     const repo = queryRunner.manager.getRepository(Event);
     return this._baseDatabase.saveEventEntity(repo, entity);

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -188,6 +188,10 @@ export class Indexer implements IndexerInterface {
     return this._storageLayoutMap;
   }
 
+  get contractMap (): Map<string, ethers.utils.Interface> {
+    return this._contractMap;
+  }
+
   {{#if (subgraphPath)}}
   get graphWatcher (): GraphWatcher {
     return this._graphWatcher;
@@ -669,6 +673,10 @@ export class Indexer implements IndexerInterface {
 
   async getEventsInRange (fromBlockNumber: number, toBlockNumber: number): Promise<Array<Event>> {
     return this._baseIndexer.getEventsInRange(fromBlockNumber, toBlockNumber, this._serverConfig.gql.maxEventsBlockRange);
+  }
+
+  async getEvents (options: FindManyOptions<Event>): Promise<Array<Event>> {
+    return this._db.getEvents(options);
   }
 
   async getSyncStatus (): Promise<SyncStatus | undefined> {

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.106",
-    "@cerc-io/ipld-eth-client": "^0.2.106",
-    "@cerc-io/solidity-mapper": "^0.2.106",
-    "@cerc-io/util": "^0.2.106",
+    "@cerc-io/cli": "^0.2.107",
+    "@cerc-io/ipld-eth-client": "^0.2.107",
+    "@cerc-io/solidity-mapper": "^0.2.107",
+    "@cerc-io/util": "^0.2.107",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.106",
+    "@cerc-io/graph-node": "^0.2.107",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.106",
+    "@cerc-io/solidity-mapper": "^0.2.107",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.106",
-    "@cerc-io/ipld-eth-client": "^0.2.106",
-    "@cerc-io/util": "^0.2.106",
+    "@cerc-io/cache": "^0.2.107",
+    "@cerc-io/ipld-eth-client": "^0.2.107",
+    "@cerc-io/util": "^0.2.107",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/graph-node/test/utils/indexer.ts
+++ b/packages/graph-node/test/utils/indexer.ts
@@ -91,6 +91,12 @@ export class Indexer implements IndexerInterface {
     return undefined;
   }
 
+  async getEvents (options: FindManyOptions<EventInterface>): Promise<Array<EventInterface>> {
+    assert(options);
+
+    return [];
+  }
+
   async getSyncStatus (): Promise<SyncStatusInterface | undefined> {
     return undefined;
   }

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.106",
-    "@cerc-io/util": "^0.2.106",
+    "@cerc-io/cache": "^0.2.107",
+    "@cerc-io/util": "^0.2.107",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.106",
-    "@cerc-io/ipld-eth-client": "^0.2.106",
-    "@cerc-io/util": "^0.2.106",
+    "@cerc-io/cache": "^0.2.107",
+    "@cerc-io/ipld-eth-client": "^0.2.107",
+    "@cerc-io/util": "^0.2.107",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.106",
-    "@cerc-io/solidity-mapper": "^0.2.106",
+    "@cerc-io/peer": "^0.2.107",
+    "@cerc-io/solidity-mapper": "^0.2.107",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -55,7 +55,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.106",
+    "@cerc-io/cache": "^0.2.107",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -255,6 +255,9 @@ export interface ServerConfig {
 
   // Enable ETH JSON RPC server at /rpc
   enableEthRPCServer: boolean;
+
+  // Max number of logs that can be returned in a single getLogs request
+  ethGetLogsResultLimit?: number;
 }
 
 export interface FundingAmountsConfig {

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -30,3 +30,5 @@ export const DEFAULT_PREFETCH_BATCH_SIZE = 10;
 export const DEFAULT_MAX_GQL_CACHE_SIZE = Math.pow(2, 20) * 8; // 8 MB
 
 export const SUPPORTED_PAID_RPC_METHODS = ['eth_getBlockByHash', 'eth_getStorageAt', 'eth_getBlockByNumber'];
+
+export const DEFAULT_ETH_GET_LOGS_RESULT_LIMIT = 10000;

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -524,7 +524,6 @@ export class Database {
   }
 
   async getEvents (repo: Repository<EventInterface>, options: FindManyOptions<EventInterface>): Promise<Array<EventInterface>> {
-    // TODO: Filter out pruned blocks
     const events = repo.find(options);
 
     return events;

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -523,6 +523,13 @@ export class Database {
     return events;
   }
 
+  async getEvents (repo: Repository<EventInterface>, options: FindManyOptions<EventInterface>): Promise<Array<EventInterface>> {
+    // TODO: Filter out pruned blocks
+    const events = repo.find(options);
+
+    return events;
+  }
+
   async saveEventEntity (repo: Repository<EventInterface>, entity: EventInterface): Promise<EventInterface> {
     const event = await repo.save(entity);
     eventCount.inc(1);

--- a/packages/util/src/server.ts
+++ b/packages/util/src/server.ts
@@ -110,7 +110,13 @@ export const createAndStartServer = async (
     app.use(
       ETH_RPC_PATH,
       jsonParser(),
-      // TODO: Handle GET requests as well to match Geth's behaviour
+      (req: any, res: any, next: () => void) => {
+        // Convert all GET requests to POST to avoid getting rejected from jayson server middleware
+        if (jayson.Utils.isMethod(req, 'GET')) {
+          req.method = 'POST';
+        }
+        next();
+      },
       rpcServer.middleware()
     );
   }

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -169,6 +169,7 @@ export interface IndexerInterface {
   getBlockProgressEntities (where: FindConditions<BlockProgressInterface>, options: FindManyOptions<BlockProgressInterface>): Promise<BlockProgressInterface[]>
   getEntitiesForBlock (blockHash: string, tableName: string): Promise<any[]>
   getEvent (id: string): Promise<EventInterface | undefined>
+  getEvents (options: FindManyOptions<EventInterface>): Promise<Array<EventInterface>>
   getSyncStatus (): Promise<SyncStatusInterface | undefined>
   getStateSyncStatus (): Promise<StateSyncStatusInterface | undefined>
   getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<Array<EthFullBlock | null>>


### PR DESCRIPTION
Part of [Watcher ETH JSON-RPC wrapper](https://www.notion.so/Watcher-ETH-JSON-RPC-wrapper-ba817da117c643779538aee6e2ebae0f)
Follows https://github.com/cerc-io/watcher-ts/pull/535

- Added support for `eth_getLogs` RPC method
- To be handled:
  - Support topics filters in `eth_getLogs`