### PR TITLE
Patch for handling `totalDifficulty` in release `v0.2.98`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.98",
-    "@cerc-io/ipld-eth-client": "^0.2.98",
+    "@cerc-io/cache": "^0.2.98-patch.1",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.98",
-    "@cerc-io/rpc-eth-client": "^0.2.98",
-    "@cerc-io/util": "^0.2.98",
+    "@cerc-io/peer": "^0.2.98-patch.1",
+    "@cerc-io/rpc-eth-client": "^0.2.98-patch.1",
+    "@cerc-io/util": "^0.2.98-patch.1",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.98",
+    "@cerc-io/util": "^0.2.98-patch.1",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.98",
-    "@cerc-io/ipld-eth-client": "^0.2.98",
-    "@cerc-io/solidity-mapper": "^0.2.98",
-    "@cerc-io/util": "^0.2.98",
+    "@cerc-io/cli": "^0.2.98-patch.1",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
+    "@cerc-io/solidity-mapper": "^0.2.98-patch.1",
+    "@cerc-io/util": "^0.2.98-patch.1",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.98",
+    "@cerc-io/graph-node": "^0.2.98-patch.1",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.98",
+    "@cerc-io/solidity-mapper": "^0.2.98-patch.1",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.98",
-    "@cerc-io/ipld-eth-client": "^0.2.98",
-    "@cerc-io/util": "^0.2.98",
+    "@cerc-io/cache": "^0.2.98-patch.1",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
+    "@cerc-io/util": "^0.2.98-patch.1",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.98",
-    "@cerc-io/util": "^0.2.98",
+    "@cerc-io/cache": "^0.2.98-patch.1",
+    "@cerc-io/util": "^0.2.98-patch.1",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/peer",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "description": "libp2p module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.98",
-    "@cerc-io/ipld-eth-client": "^0.2.98",
-    "@cerc-io/util": "^0.2.98",
+    "@cerc-io/cache": "^0.2.98-patch.1",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
+    "@cerc-io/util": "^0.2.98-patch.1",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/rpc-eth-client/src/eth-client.ts
+++ b/packages/rpc-eth-client/src/eth-client.ts
@@ -130,7 +130,7 @@ export class EthClient implements EthClientInterface {
             parentHash: block.parentHash,
             timestamp: block.timestamp.toString(),
             stateRoot: this._provider.formatter.hash(rawBlock.stateRoot),
-            td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty).toString(),
+            td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty ?? 0).toString(),
             txRoot: this._provider.formatter.hash(rawBlock.transactionsRoot),
             receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot)
           }
@@ -191,7 +191,7 @@ export class EthClient implements EthClientInterface {
           parentHash: this._provider.formatter.hash(rawBlock.parentHash),
           timestamp: this._provider.formatter.number(rawBlock.timestamp).toString(),
           stateRoot: this._provider.formatter.hash(rawBlock.stateRoot),
-          td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty).toString(),
+          td: this._provider.formatter.bigNumber(rawBlock.totalDifficulty ?? 0).toString(),
           txRoot: this._provider.formatter.hash(rawBlock.transactionsRoot),
           receiptRoot: this._provider.formatter.hash(rawBlock.receiptsRoot),
           uncleRoot: this._provider.formatter.hash(rawBlock.sha3Uncles),

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.98",
+  "version": "0.2.98-patch.1",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
-    "@cerc-io/peer": "^0.2.98",
-    "@cerc-io/solidity-mapper": "^0.2.98",
+    "@cerc-io/peer": "^0.2.98-patch.1",
+    "@cerc-io/solidity-mapper": "^0.2.98-patch.1",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",
@@ -54,7 +54,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
-    "@cerc-io/cache": "^0.2.98",
+    "@cerc-io/cache": "^0.2.98-patch.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/bunyan": "^1.8.8",
     "@types/express": "^4.17.14",


### PR DESCRIPTION
- Reference: https://github.com/ethereum/execution-apis/pull/570
- Watcher `v0.2.98` is used in https://github.com/cerc-io/azimuth-watcher-ts
- Fix in main: https://github.com/cerc-io/watcher-ts/pull/540
