### PR TITLE
Add filter for event name in eventsInRange GQL query

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cache",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "description": "Generic object cache",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/cli",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "scripts": {
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.98-patch.1",
-    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
+    "@cerc-io/cache": "^0.2.98-patch.2",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.2",
     "@cerc-io/libp2p": "^0.42.2-laconic-0.1.4",
     "@cerc-io/nitro-node": "^0.1.15",
     "@cerc-io/peer": "0.2.98",
-    "@cerc-io/rpc-eth-client": "^0.2.98-patch.1",
-    "@cerc-io/util": "^0.2.98-patch.1",
+    "@cerc-io/rpc-eth-client": "^0.2.98-patch.2",
+    "@cerc-io/util": "^0.2.98-patch.2",
     "@ethersproject/providers": "^5.4.4",
     "@graphql-tools/utils": "^9.1.1",
     "@ipld/dag-cbor": "^8.0.0",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/codegen",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "description": "Code generator",
   "private": true,
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/util": "^0.2.98-patch.1",
+    "@cerc-io/util": "^0.2.98-patch.2",
     "@graphql-tools/load-files": "^6.5.2",
     "@npmcli/package-json": "^5.0.0",
     "@poanet/solidity-flattener": "https://github.com/vulcanize/solidity-flattener.git",

--- a/packages/codegen/src/schema.ts
+++ b/packages/codegen/src/schema.ts
@@ -579,7 +579,8 @@ export class Schema {
         type: this._composer.getOTC('ResultEvent').NonNull.List,
         args: {
           fromBlockNumber: 'Int!',
-          toBlockNumber: 'Int!'
+          toBlockNumber: 'Int!',
+          name: 'String'
         }
       }
     });

--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -193,10 +193,10 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getProcessedBlockCountForRange(repo, fromBlockNumber, toBlockNumber);
   }
 
-  async getEventsInRange (fromBlockNumber: number, toBlockNumber: number): Promise<Array<Event>> {
+  async getEventsInRange (fromBlockNumber: number, toBlockNumber: number, name?: string): Promise<Array<Event>> {
     const repo = this._conn.getRepository(Event);
 
-    return this._baseDatabase.getEventsInRange(repo, fromBlockNumber, toBlockNumber);
+    return this._baseDatabase.getEventsInRange(repo, fromBlockNumber, toBlockNumber, name);
   }
 
   async saveEventEntity (queryRunner: QueryRunner, entity: Event): Promise<Event> {

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -659,8 +659,8 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getProcessedBlockCountForRange(fromBlockNumber, toBlockNumber);
   }
 
-  async getEventsInRange (fromBlockNumber: number, toBlockNumber: number): Promise<Array<Event>> {
-    return this._baseIndexer.getEventsInRange(fromBlockNumber, toBlockNumber, this._serverConfig.gql.maxEventsBlockRange);
+  async getEventsInRange (fromBlockNumber: number, toBlockNumber: number, name?: string): Promise<Array<Event>> {
+    return this._baseIndexer.getEventsInRange(fromBlockNumber, toBlockNumber, name, this._serverConfig.gql.maxEventsBlockRange);
   }
 
   async getSyncStatus (): Promise<SyncStatus | undefined> {

--- a/packages/codegen/src/templates/package-template.handlebars
+++ b/packages/codegen/src/templates/package-template.handlebars
@@ -41,12 +41,12 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.3.19",
-    "@cerc-io/cli": "^0.2.98-patch.1",
-    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
-    "@cerc-io/solidity-mapper": "^0.2.98-patch.1",
-    "@cerc-io/util": "^0.2.98-patch.1",
+    "@cerc-io/cli": "^0.2.98-patch.2",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.2",
+    "@cerc-io/solidity-mapper": "^0.2.98-patch.2",
+    "@cerc-io/util": "^0.2.98-patch.2",
     {{#if (subgraphPath)}}
-    "@cerc-io/graph-node": "^0.2.98-patch.1",
+    "@cerc-io/graph-node": "^0.2.98-patch.2",
     {{/if}}
     "@ethersproject/providers": "^5.4.4",
     "debug": "^4.3.1",

--- a/packages/codegen/src/templates/resolvers-template.handlebars
+++ b/packages/codegen/src/templates/resolvers-template.handlebars
@@ -225,10 +225,10 @@ export const createResolvers = async (
 
       eventsInRange: async (
         _: any,
-        { fromBlockNumber, toBlockNumber }: { fromBlockNumber: number, toBlockNumber: number },
+        { fromBlockNumber, toBlockNumber, name }: { fromBlockNumber: number, toBlockNumber: number, name?: string },
         expressContext: ExpressContext
       ) => {
-        log('eventsInRange', fromBlockNumber, toBlockNumber);
+        log('eventsInRange', fromBlockNumber, toBlockNumber, name);
 
         return executeAndRecordMetrics(
           indexer,
@@ -246,7 +246,7 @@ export const createResolvers = async (
               throw new Error(`Block range should be between ${syncStatus.initialIndexedBlockNumber} and ${syncStatus.latestProcessedBlockNumber}`);
             }
 
-            const events = await indexer.getEventsInRange(fromBlockNumber, toBlockNumber);
+            const events = await indexer.getEventsInRange(fromBlockNumber, toBlockNumber, name);
             return events.map(event => indexer.getResultEvent(event));
           }
         );

--- a/packages/graph-node/package.json
+++ b/packages/graph-node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@cerc-io/graph-node",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@cerc-io/solidity-mapper": "^0.2.98-patch.1",
+    "@cerc-io/solidity-mapper": "^0.2.98-patch.2",
     "@ethersproject/providers": "^5.4.4",
     "@graphprotocol/graph-ts": "^0.22.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -51,9 +51,9 @@
   "dependencies": {
     "@apollo/client": "^3.3.19",
     "@cerc-io/assemblyscript": "0.19.10-watcher-ts-0.1.2",
-    "@cerc-io/cache": "^0.2.98-patch.1",
-    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
-    "@cerc-io/util": "^0.2.98-patch.1",
+    "@cerc-io/cache": "^0.2.98-patch.2",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.2",
+    "@cerc-io/util": "^0.2.98-patch.2",
     "@types/json-diff": "^0.5.2",
     "@types/yargs": "^17.0.0",
     "bn.js": "^4.11.9",

--- a/packages/ipld-eth-client/package.json
+++ b/packages/ipld-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/ipld-eth-client",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "description": "IPLD ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
     "@apollo/client": "^3.7.1",
-    "@cerc-io/cache": "^0.2.98-patch.1",
-    "@cerc-io/util": "^0.2.98-patch.1",
+    "@cerc-io/cache": "^0.2.98-patch.2",
+    "@cerc-io/util": "^0.2.98-patch.2",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",
     "ethers": "^5.4.4",

--- a/packages/rpc-eth-client/package.json
+++ b/packages/rpc-eth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/rpc-eth-client",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "description": "RPC ETH Client",
   "main": "dist/index.js",
   "scripts": {
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/cerc-io/watcher-ts#readme",
   "dependencies": {
-    "@cerc-io/cache": "^0.2.98-patch.1",
-    "@cerc-io/ipld-eth-client": "^0.2.98-patch.1",
-    "@cerc-io/util": "^0.2.98-patch.1",
+    "@cerc-io/cache": "^0.2.98-patch.2",
+    "@cerc-io/ipld-eth-client": "^0.2.98-patch.2",
+    "@cerc-io/util": "^0.2.98-patch.2",
     "chai": "^4.3.4",
     "ethers": "^5.4.4",
     "left-pad": "^1.3.0",

--- a/packages/solidity-mapper/package.json
+++ b/packages/solidity-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/solidity-mapper",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "devDependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/test",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "private": true,

--- a/packages/tracing-client/package.json
+++ b/packages/tracing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/tracing-client",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "description": "ETH VM tracing client",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cerc-io/util",
-  "version": "0.2.98-patch.1",
+  "version": "0.2.98-patch.2",
   "main": "dist/index.js",
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@cerc-io/nitro-node": "^0.1.15",
     "@cerc-io/peer": "0.2.98",
-    "@cerc-io/solidity-mapper": "^0.2.98-patch.1",
+    "@cerc-io/solidity-mapper": "^0.2.98-patch.2",
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
     "@ethersproject/properties": "^5.7.0",
     "@ethersproject/providers": "^5.4.4",

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -509,18 +509,22 @@ export class Database {
     return { expected, actual: parseInt(actual) };
   }
 
-  async getEventsInRange (repo: Repository<EventInterface>, fromBlockNumber: number, toBlockNumber: number): Promise<Array<EventInterface>> {
-    const events = repo.createQueryBuilder('event')
+  async getEventsInRange (repo: Repository<EventInterface>, fromBlockNumber: number, toBlockNumber: number, name?: string): Promise<Array<EventInterface>> {
+    const queryBuilder = repo.createQueryBuilder('event')
       .innerJoinAndSelect('event.block', 'block')
       .where('block_number >= :fromBlockNumber AND block_number <= :toBlockNumber AND event_name <> :eventName AND is_pruned = false', {
         fromBlockNumber,
         toBlockNumber,
         eventName: UNKNOWN_EVENT_NAME
-      })
+      });
+
+    if (name) {
+      queryBuilder.andWhere('event.event_name = :name', { name });
+    }
+
+    return queryBuilder
       .addOrderBy('event.id', 'ASC')
       .getMany();
-
-    return events;
   }
 
   async saveEventEntity (repo: Repository<EventInterface>, entity: EventInterface): Promise<EventInterface> {

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -789,7 +789,7 @@ export class Indexer {
     return this._db.getProcessedBlockCountForRange(fromBlockNumber, toBlockNumber);
   }
 
-  async getEventsInRange (fromBlockNumber: number, toBlockNumber: number, maxBlockRange: number = DEFAULT_MAX_EVENTS_BLOCK_RANGE): Promise<Array<EventInterface>> {
+  async getEventsInRange (fromBlockNumber: number, toBlockNumber: number, maxBlockRange: number = DEFAULT_MAX_EVENTS_BLOCK_RANGE, name?: string): Promise<Array<EventInterface>> {
     if (toBlockNumber <= fromBlockNumber) {
       throw new Error('toBlockNumber should be greater than fromBlockNumber');
     }
@@ -798,7 +798,7 @@ export class Indexer {
       throw new Error(`Max range (${maxBlockRange}) exceeded`);
     }
 
-    return this._db.getEventsInRange(fromBlockNumber, toBlockNumber);
+    return this._db.getEventsInRange(fromBlockNumber, toBlockNumber, name);
   }
 
   isWatchedContract (address : string): ContractInterface | undefined {
@@ -1359,7 +1359,7 @@ export class Indexer {
     }
   }
 
-  async clearProcessedBlockData (block: BlockProgressInterface, entities: EntityTarget<{ blockNumber: number }>[]): Promise<void> {
+  async clearProcessedBlockData (block: BlockProgressInterface, entities: EntityTarget<{ blockNumber: number, blockHash: string }>[]): Promise<void> {
     const dbTx = await this._db.createTransactionRunner();
 
     try {

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -254,7 +254,7 @@ export interface DatabaseInterface {
   getSyncStatus (queryRunner: QueryRunner): Promise<SyncStatusInterface | undefined>
   getAncestorAtHeight (blockHash: string, height: number): Promise<string>
   getProcessedBlockCountForRange (fromBlockNumber: number, toBlockNumber: number): Promise<{ expected: number, actual: number }>;
-  getEventsInRange (fromBlockNumber: number, toBlockNumber: number): Promise<Array<EventInterface>>;
+  getEventsInRange (fromBlockNumber: number, toBlockNumber: number, name?: string): Promise<Array<EventInterface>>;
   markBlocksAsPruned (queryRunner: QueryRunner, blocks: BlockProgressInterface[]): Promise<void>;
   saveBlockProgress (queryRunner: QueryRunner, block: DeepPartial<BlockProgressInterface>): Promise<BlockProgressInterface>;
   updateBlockProgress (queryRunner: QueryRunner, block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface>


### PR DESCRIPTION
Part of https://www.notion.so/Handle-galaxy-star-ownership-transfers-1b4a6b22d47280039403d25edf479948
```bash
✗ curl 'http://localhost:3001/graphql' \
  -H 'content-type: application/json' \
  --data-raw '{"query":"{\n  eventsInRange(fromBlockNumber: 6839505, toBlockNumber: 6839506, name: \"OwnerChanged\") {\n    block {\n      number\n    }\n    event {\n      __typename\n    }\n  }\n}","variables":{"fromBlockNumber":6839505,"toBlockNumber":6839506}}' | jq

{
  "data": {
    "eventsInRange": [
      {
        "block": {
          "number": 6839506
        },
        "event": {
          "__typename": "OwnerChangedEvent"
        }
      },
      {
        "block": {
          "number": 6839506
        },
        "event": {
          "__typename": "OwnerChangedEvent"
        }
      },
      ...
    ]
  }
}
```